### PR TITLE
feat: add run summary with statistics on completion

### DIFF
--- a/ralph_pp/orchestrator.py
+++ b/ralph_pp/orchestrator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shutil
+import time
 from pathlib import Path
 
 from rich.console import Console
@@ -12,14 +13,14 @@ from rich.rule import Rule
 from .config import Config
 from .hooks import run_hooks
 from .skills import ensure_prd_skills
-from .steps.post_review import post_review_loop
+from .steps.post_review import PostReviewResult, post_review_loop
 from .steps.prd import (
     convert_prd_to_json,
     feature_to_slug,
     generate_prd,
     review_prd_loop,
 )
-from .steps.sandbox import run_sandbox
+from .steps.sandbox import RunSummary, run_sandbox
 from .steps.worktree import cleanup_git_config, create_worktree
 
 console = Console()
@@ -32,6 +33,8 @@ class Orchestrator:
         self.dry_run = dry_run
         self.worktree_path: Path | None = None
         self.branch: str | None = None
+        self._run_summary: RunSummary | None = None
+        self._review_result: PostReviewResult | None = None
 
     def run(
         self,
@@ -47,6 +50,7 @@ class Orchestrator:
             console.print("[yellow]DRY RUN — no commands will be executed[/yellow]")
             return
 
+        start_time = time.monotonic()
         try:
             if prd_only:
                 self._step_prd_only(skip_prd_review)
@@ -64,14 +68,8 @@ class Orchestrator:
             console.print("[bold red]\n✗ Workflow failed:[/bold red] " + str(exc))
             raise
 
-        console.print(Rule(style="green"))
-        summary = (
-            "✓ ralph++ complete!\nBranch: "
-            + str(self.branch)
-            + "\nWorktree: "
-            + str(self.worktree_path)
-        )
-        console.print(Panel.fit(summary, border_style="green"))
+        elapsed = time.monotonic() - start_time
+        self._print_summary(elapsed, skip_post_review)
 
     # ── Steps ──────────────────────────────────────────────────────────
 
@@ -128,9 +126,9 @@ class Orchestrator:
             label = f"{mode} mode"
         console.print(Rule(f"[bold]3 · Ralph Sandbox ({label})[/bold]"))
         run_hooks("pre_sandbox", self.config.hooks, self.worktree_path)
-        success = run_sandbox(self.worktree_path, self.config)
+        self._run_summary = run_sandbox(self.worktree_path, self.config)
         run_hooks("post_sandbox", self.config.hooks, self.worktree_path)
-        if not success:
+        if not self._run_summary.sandbox_ok:
             console.print(
                 "[yellow]⚠ Ralph did not signal COMPLETE — "
                 "continuing to post-review anyway[/yellow]"
@@ -139,10 +137,48 @@ class Orchestrator:
     def _step_post_review(self) -> None:
         assert self.worktree_path is not None
         console.print(Rule("[bold]4 · Post-Run Review[/bold]"))
-        post_review_loop(self.worktree_path, self.config)
+        self._review_result = post_review_loop(self.worktree_path, self.config)
 
     def _step_cleanup(self) -> None:
         assert self.worktree_path is not None
         console.print(Rule("[bold]5 · Cleanup[/bold]"))
         cleanup_git_config(self.worktree_path)
         run_hooks("post_complete", self.config.hooks, self.worktree_path)
+
+    def _print_summary(self, elapsed: float, skip_post_review: bool) -> None:
+        console.print(Rule(style="green"))
+
+        mins, secs = divmod(int(elapsed), 60)
+        duration = f"{mins}m {secs:02d}s" if mins else f"{secs}s"
+
+        lines = ["[bold green]✓ ralph++ complete![/bold green]", ""]
+
+        if self._run_summary:
+            s = self._run_summary
+            lines.append(f"Mode:         {s.mode}")
+            lines.append(f"Duration:     {duration}")
+            lines.append(f"Iterations:   {s.iterations}")
+            lines.append(f"Stories:      {s.stories_completed}/{s.stories_total} completed")
+            if s.retries:
+                lines.append(f"Retries:      {s.retries}")
+            lines.append(f"SHA:          {s.base_sha[:7]} → {s.final_sha[:7]}")
+        else:
+            lines.append(f"Duration:     {duration}")
+
+        if self._review_result:
+            r = self._review_result
+            if r.outcome == "lgtm":
+                review_str = f"LGTM ({r.cycles} cycle{'s' if r.cycles != 1 else ''})"
+            elif r.outcome == "accepted":
+                review_str = f"accepted without approval ({r.cycles} cycles)"
+            else:
+                review_str = r.outcome
+            lines.append(f"Post-review:  {review_str}")
+        elif skip_post_review:
+            lines.append("Post-review:  skipped")
+
+        lines.append("")
+        lines.append(f"Branch:       {self.branch}")
+        lines.append(f"Worktree:     {self.worktree_path}")
+
+        console.print(Panel.fit("\n".join(lines), border_style="green"))

--- a/ralph_pp/steps/post_review.py
+++ b/ralph_pp/steps/post_review.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 from rich.console import Console
@@ -15,7 +16,15 @@ from .sandbox import BASE_SHA_FILE, format_all_completed
 console = Console()
 
 
-def post_review_loop(worktree_path: Path, config: Config) -> None:
+@dataclass
+class PostReviewResult:
+    """Outcome of the post-run review loop."""
+
+    outcome: str  # "lgtm", "accepted", "skipped"
+    cycles: int  # total review cycles run
+
+
+def post_review_loop(worktree_path: Path, config: Config) -> PostReviewResult:
     """
     After the Ralph sandbox completes, run a full review of the implementation
     against prd.json. Iteratively fix issues until LGTM or max_cycles reached.
@@ -26,7 +35,7 @@ def post_review_loop(worktree_path: Path, config: Config) -> None:
     review_cfg: PostReviewConfig = config.post_review
     if not review_cfg.enabled:
         console.print("[dim]Post-run review disabled — skipping[/dim]")
-        return
+        return PostReviewResult(outcome="skipped", cycles=0)
 
     console.print("[bold cyan]\n── Step: Post-Run Review Loop ──[/bold cyan]")
     if config.orchestrated.auto_allow_test_commands and config.orchestrated.test_commands:
@@ -122,7 +131,7 @@ def post_review_loop(worktree_path: Path, config: Config) -> None:
 
             if result.is_lgtm:
                 console.print("[green]✓ Post-run review passed (LGTM)[/green]")
-                return
+                return PostReviewResult(outcome="lgtm", cycles=total_cycles)
 
             previous_findings = result.output
             console.print(
@@ -149,6 +158,6 @@ def post_review_loop(worktree_path: Path, config: Config) -> None:
             raise MaxCyclesAbort
         if action == "continue":
             console.print("[yellow]Accepting implementation without reviewer approval[/yellow]")
-            return
+            return PostReviewResult(outcome="accepted", cycles=total_cycles)
         # action == "retry" → loop again
         console.print(f"[cyan]Retrying another {review_cfg.max_cycles} review cycles...[/cyan]")

--- a/ralph_pp/steps/sandbox.py
+++ b/ralph_pp/steps/sandbox.py
@@ -100,11 +100,27 @@ COMPLETE_SIGNAL = "<promise>COMPLETE</promise>"
 BASE_SHA_FILE = "scripts/ralph/.base-sha"
 
 
-def run_sandbox(worktree_path: Path, config: Config) -> bool:
+@dataclass
+class RunSummary:
+    """Summary statistics from a sandbox run."""
+
+    mode: str  # e.g. "orchestrated (backout)", "delegated"
+    sandbox_ok: bool  # whether the sandbox signaled success
+    iterations: int  # total iterations run (0 for delegated)
+    stories_completed: int
+    stories_total: int
+    base_sha: str
+    final_sha: str
+    retries: int  # total backout retries or fix cycles
+
+
+def run_sandbox(worktree_path: Path, config: Config) -> RunSummary:
     """Run the Ralph loop. Dispatches to delegated or orchestrated mode.
 
     Saves the pre-run HEAD SHA to ``scripts/ralph/.base-sha`` so that the
     post-run review can diff against the starting point.
+
+    Returns a :class:`RunSummary` with statistics about the run.
     """
     base_sha = get_head_sha(worktree_path)
     base_sha_path = worktree_path / BASE_SHA_FILE
@@ -112,8 +128,44 @@ def run_sandbox(worktree_path: Path, config: Config) -> bool:
     base_sha_path.write_text(base_sha)
 
     if config.ralph.mode == "orchestrated":
-        return _run_orchestrated(worktree_path, config)
-    return _run_delegated(worktree_path, config)
+        success = _run_orchestrated(worktree_path, config)
+    else:
+        success = _run_delegated(worktree_path, config)
+
+    # Build summary from post-run state
+    prd_json = worktree_path / "scripts" / "ralph" / "prd.json"
+    story_status = read_story_status(prd_json) if prd_json.exists() else {}
+    completed = sum(1 for v in story_status.values() if v)
+
+    orch = config.orchestrated
+    if config.ralph.mode == "orchestrated":
+        strategy = "backout" if orch.backout_on_failure else "fixup"
+        mode = f"orchestrated ({strategy})"
+    else:
+        mode = "delegated"
+
+    # Read iteration/retry counters written by _run_orchestrated
+    counters_path = worktree_path / "scripts" / "ralph" / ".run-counters"
+    iterations = 0
+    retries = 0
+    if counters_path.exists():
+        for line in counters_path.read_text().splitlines():
+            key, _, val = line.partition("=")
+            if key == "iterations":
+                iterations = int(val)
+            elif key == "retries":
+                retries = int(val)
+
+    return RunSummary(
+        mode=mode,
+        sandbox_ok=success,
+        iterations=iterations,
+        stories_completed=completed,
+        stories_total=len(story_status),
+        base_sha=base_sha,
+        final_sha=get_head_sha(worktree_path),
+        retries=retries,
+    )
 
 
 # ── Helpers ─────────────────────────────────────────────────────────────
@@ -481,8 +533,14 @@ def _run_orchestrated(worktree_path: Path, config: Config) -> bool:
 
     last_findings = ""
     consecutive_idle = 0
+    total_retries = 0
     prev_story_status = read_story_status(prd_json)
     total_stories = len(prev_story_status)
+
+    def _save_counters(iters: int) -> None:
+        """Persist iteration/retry counters for RunSummary."""
+        counters = worktree_path / "scripts" / "ralph" / ".run-counters"
+        counters.write_text(f"iterations={iters}\nretries={total_retries}\n")
 
     for iteration in range(1, config.ralph.max_iterations + 1):
         completed = sum(1 for v in prev_story_status.values() if v)
@@ -570,6 +628,7 @@ def _run_orchestrated(worktree_path: Path, config: Config) -> bool:
                 story_status = read_story_status(prd_json)
                 if all(story_status.values()):
                     console.print("[green]Ralph signaled COMPLETE[/green]")
+                    _save_counters(iteration)
                     return True
                 incomplete = [sid for sid, p in story_status.items() if not p]
                 console.print(
@@ -590,6 +649,7 @@ def _run_orchestrated(worktree_path: Path, config: Config) -> bool:
                         f"[green]No changes for {consecutive_idle} consecutive iterations "
                         "— treating as complete[/green]"
                     )
+                    _save_counters(iteration)
                     return True
                 console.print(
                     f"  [dim]No changes this iteration "
@@ -665,15 +725,18 @@ def _run_orchestrated(worktree_path: Path, config: Config) -> bool:
             if orch.backout_on_failure:
                 # PATH A: Backout and retry
                 if attempt < max_attempts:
+                    total_retries += 1
                     _backout_to(worktree_path, pre_sha, restore_files=restore_files)
                 else:
                     console.print(
                         f"  [red]✗ All retries exhausted for iteration {iteration} — aborting[/red]"
                     )
+                    _save_counters(iteration)
                     return False
             else:
                 # PATH B: Invoke fixer to fix in-place
                 for fix_cycle in range(1, orch.max_iteration_retries + 1):
+                    total_retries += 1
                     console.print(
                         f"  [dim]Fix cycle {fix_cycle}/{orch.max_iteration_retries}[/dim]"
                     )
@@ -729,6 +792,7 @@ def _run_orchestrated(worktree_path: Path, config: Config) -> bool:
                     console.print(
                         f"  [red]✗ Fix cycles exhausted for iteration {iteration} — aborting[/red]"
                     )
+                    _save_counters(iteration)
                     return False
                 break  # In fix-in-place mode we don't retry the coder, only the fixer
 
@@ -748,4 +812,5 @@ def _run_orchestrated(worktree_path: Path, config: Config) -> bool:
         f"[yellow]Reached max iterations ({config.ralph.max_iterations}) "
         "without completion signal[/yellow]"
     )
+    _save_counters(config.ralph.max_iterations)
     return False


### PR DESCRIPTION
Print a summary panel at the end of each ralph++ run showing:
- Mode (orchestrated backout/fixup, delegated)
- Wall-clock duration
- Iterations completed and stories completed/total
- Total retries (backout retries or fix cycles)
- Base SHA to final SHA
- Post-review outcome and cycle count
- Branch and worktree path

Introduces RunSummary (returned by run_sandbox) and PostReviewResult (returned by post_review_loop) dataclasses to carry statistics up to the orchestrator. Internal functions (_run_orchestrated, _run_delegated) still return bool to avoid test churn.