### PR TITLE
feat: add --manual-prd flag for interactive PRD generation

### DIFF
--- a/ralph_pp/cli.py
+++ b/ralph_pp/cli.py
@@ -180,6 +180,13 @@ _sandbox_dir_option = click.option(
     help="Path to an existing text PRD. Skips generation/review, proceeds to implementation.",
 )
 @click.option(
+    "--manual-prd",
+    is_flag=True,
+    default=False,
+    help="Open an interactive Claude session for PRD generation without "
+    "auto-prompting the feature description. Use the /prd skill manually.",
+)
+@click.option(
     "--dry-run",
     is_flag=True,
     default=False,
@@ -199,6 +206,7 @@ def run(
     sandbox_dir: Path | None,
     prd_only: bool,
     prd_file: Path | None,
+    manual_prd: bool,
     dry_run: bool,
 ) -> None:
     """Run the full Ralph agentic coding workflow."""
@@ -232,6 +240,7 @@ def run(
         skip_post_review=skip_post_review,
         prd_only=prd_only,
         prd_file=prd_file,
+        manual_prd=manual_prd,
     )
 
 

--- a/ralph_pp/orchestrator.py
+++ b/ralph_pp/orchestrator.py
@@ -42,6 +42,7 @@ class Orchestrator:
         skip_post_review: bool = False,
         prd_only: bool = False,
         prd_file: Path | None = None,
+        manual_prd: bool = False,
     ) -> None:
         title = "ralph++\nFeature: " + self.feature
         console.print(Panel.fit(title, border_style="bright_blue"))
@@ -53,13 +54,13 @@ class Orchestrator:
         start_time = time.monotonic()
         try:
             if prd_only:
-                self._step_prd_only(skip_prd_review)
+                self._step_prd_only(skip_prd_review, manual_prd=manual_prd)
                 return
             self._step_worktree()
             if prd_file is not None:
                 self._step_prd_from_file(prd_file)
             else:
-                self._step_prd(skip_prd_review)
+                self._step_prd(skip_prd_review, manual_prd=manual_prd)
             self._step_sandbox()
             if not skip_post_review:
                 self._step_post_review()
@@ -78,13 +79,13 @@ class Orchestrator:
         self.worktree_path, self.branch = create_worktree(self.feature, self.config)
         run_hooks("post_worktree_create", self.config.hooks, self.worktree_path)
 
-    def _step_prd_only(self, skip_review: bool) -> None:
+    def _step_prd_only(self, skip_review: bool, *, manual_prd: bool = False) -> None:
         """Generate (and optionally review) the text PRD, then stop."""
         base = self.config.repo_path
         console.print(Rule("[bold]PRD Only[/bold]"))
         ensure_prd_skills(self.config, base)
         run_hooks("pre_prd_generate", self.config.hooks, base)
-        prd_file = generate_prd(self.feature, base, self.config)
+        prd_file = generate_prd(self.feature, base, self.config, manual=manual_prd)
         run_hooks("post_prd_generate", self.config.hooks, base)
         if not skip_review:
             review_prd_loop(prd_file, base, self.config)
@@ -105,12 +106,12 @@ class Orchestrator:
         console.print(f"[green]✓ PRD copied:[/green] {prd_file} → {dest}")
         convert_prd_to_json(dest, self.worktree_path, self.config)
 
-    def _step_prd(self, skip_review: bool) -> None:
+    def _step_prd(self, skip_review: bool, *, manual_prd: bool = False) -> None:
         assert self.worktree_path is not None
         console.print(Rule("[bold]2 · PRD[/bold]"))
         ensure_prd_skills(self.config, self.worktree_path)
         run_hooks("pre_prd_generate", self.config.hooks, self.worktree_path)
-        prd_file = generate_prd(self.feature, self.worktree_path, self.config)
+        prd_file = generate_prd(self.feature, self.worktree_path, self.config, manual=manual_prd)
         run_hooks("post_prd_generate", self.config.hooks, self.worktree_path)
         if not skip_review:
             review_prd_loop(prd_file, self.worktree_path, self.config)

--- a/ralph_pp/steps/prd.py
+++ b/ralph_pp/steps/prd.py
@@ -58,30 +58,52 @@ def feature_to_slug(feature: str) -> str:
     return slug
 
 
-def generate_prd(feature: str, worktree_path: Path, config: Config) -> Path:
+def generate_prd(
+    feature: str,
+    worktree_path: Path,
+    config: Config,
+    *,
+    manual: bool = False,
+) -> Path:
     """
     Invoke the Claude /prd skill to generate a text PRD.
     Returns the path to the generated PRD markdown file.
+
+    When *manual* is True the feature description is not sent as a prompt,
+    allowing the user to drive the conversation interactively.
     """
     console.print("[bold cyan]\n── Step: Generate PRD ──[/bold cyan]")
     slug = feature_to_slug(feature)
     prd_filename = f"prd-{slug}.md"
     (worktree_path / "tasks").mkdir(exist_ok=True)
     tool = make_tool(config.prd_tool, config)
-    prompt = (
-        f"Create a PRD for the following feature: {feature}\n\n"
-        "You have the /prd skill available. Use it to generate a detailed Product "
-        "Requirements Document with goals, user stories, acceptance criteria, "
-        "non-goals, and technical considerations.\n\n"
-        f"Save the PRD to tasks/{prd_filename}"
-    )
+
+    if manual:
+        prompt = f"Save the PRD to tasks/{prd_filename} when done."
+    else:
+        prompt = (
+            f"Create a PRD for the following feature: {feature}\n\n"
+            "You have the /prd skill available. Use it to generate a detailed Product "
+            "Requirements Document with goals, user stories, acceptance criteria, "
+            "non-goals, and technical considerations.\n\n"
+            f"Save the PRD to tasks/{prd_filename}"
+        )
+
     tool_cfg = config.get_tool(config.prd_tool)
     if tool_cfg.interactive:
-        console.print(
-            "\n[bold yellow]When Claude finishes generating the PRD, "
-            "type /exit to return to ralph++.\n"
-            "Do not use Ctrl-C — it may corrupt Claude's configuration.[/bold yellow]\n"
-        )
+        if manual:
+            console.print(
+                "\n[bold yellow]You are in an interactive Claude session.\n"
+                f"Use the /prd skill to generate the PRD, then save it to tasks/{prd_filename}\n"
+                "When done, type /exit to return to ralph++.\n"
+                "Do not use Ctrl-C — it may corrupt Claude's configuration.[/bold yellow]\n"
+            )
+        else:
+            console.print(
+                "\n[bold yellow]When Claude finishes generating the PRD, "
+                "type /exit to return to ralph++.\n"
+                "Do not use Ctrl-C — it may corrupt Claude's configuration.[/bold yellow]\n"
+            )
 
     result = tool.run(prompt=prompt, cwd=worktree_path)
     if not result.success:


### PR DESCRIPTION
When --manual-prd is set, the feature description is not sent as a prompt to Claude, allowing the user to drive the PRD conversation interactively. The interactive warning is updated to remind the user to use the /prd skill and save to the expected filename before exiting.