### PR TITLE
fix: is_lgtm broken when stderr is non-empty (#10)

### DIFF
--- a/ralph_pp/steps/post_review.py
+++ b/ralph_pp/steps/post_review.py
@@ -126,7 +126,8 @@ def post_review_loop(worktree_path: Path, config: Config) -> PostReviewResult:
             result = reviewer.run(prompt=review_prompt, cwd=worktree_path)
             if not result.success:
                 raise RuntimeError(
-                    f"Post-run reviewer failed (exit {result.exit_code}): {result.output[:200]}"
+                    f"Post-run reviewer failed (exit {result.exit_code}): "
+                    f"{(result.output or result.stderr)[:200]}"
                 )
 
             if result.is_lgtm:
@@ -145,7 +146,7 @@ def post_review_loop(worktree_path: Path, config: Config) -> PostReviewResult:
             if not fix_result.success:
                 raise RuntimeError(
                     f"Post-run fixer failed (exit {fix_result.exit_code}): "
-                    f"{fix_result.output[:200]}"
+                    f"{(fix_result.output or fix_result.stderr)[:200]}"
                 )
             last_fixer_diff = get_diff(worktree_path, pre_fix_sha)
 

--- a/ralph_pp/steps/prd.py
+++ b/ralph_pp/steps/prd.py
@@ -165,7 +165,8 @@ def review_prd_loop(prd_file: Path, worktree_path: Path, config: Config) -> None
             result = reviewer.run(prompt=review_prompt, cwd=worktree_path)
             if not result.success:
                 raise RuntimeError(
-                    f"PRD reviewer failed (exit {result.exit_code}): {result.output[:200]}"
+                    f"PRD reviewer failed (exit {result.exit_code}): "
+                    f"{(result.output or result.stderr)[:200]}"
                 )
 
             if result.is_lgtm:
@@ -183,7 +184,8 @@ def review_prd_loop(prd_file: Path, worktree_path: Path, config: Config) -> None
             fix_result = fixer.run(prompt=fix_prompt, cwd=worktree_path)
             if not fix_result.success:
                 raise RuntimeError(
-                    f"PRD fixer failed (exit {fix_result.exit_code}): {fix_result.output[:200]}"
+                    f"PRD fixer failed (exit {fix_result.exit_code}): "
+                    f"{(fix_result.output or fix_result.stderr)[:200]}"
                 )
             last_fixer_diff = get_diff(worktree_path, pre_fix_sha)
 

--- a/ralph_pp/steps/sandbox.py
+++ b/ralph_pp/steps/sandbox.py
@@ -449,7 +449,8 @@ def _review_iteration(
     result = reviewer.run(prompt=review_prompt, cwd=worktree_path)
     if not result.success:
         raise RuntimeError(
-            f"Iteration reviewer failed (exit {result.exit_code}): {result.output[:200]}"
+            f"Iteration reviewer failed (exit {result.exit_code}): "
+            f"{(result.output or result.stderr)[:200]}"
         )
 
     if result.is_lgtm:

--- a/ralph_pp/tools/base.py
+++ b/ralph_pp/tools/base.py
@@ -29,12 +29,19 @@ class ToolResult:
     output: str
     exit_code: int
     success: bool
+    stderr: str = ""
 
     @property
     def is_lgtm(self) -> bool:
-        """True if the tool output signals no issues found."""
+        """True if the tool output signals no issues found.
+
+        Only checks ``output`` (stdout).  The ``stderr`` field is ignored
+        because CLI tools routinely emit warnings/deprecation notices there.
+        Tolerates common model variations like ``LGTM!``, ``LGTM.``, and
+        case-insensitive matches.
+        """
         stripped = self.output.strip()
-        return stripped == "LGTM" or stripped.startswith("LGTM\n")
+        return bool(re.match(r"^LGTM[^a-z]?($|\n)", stripped, re.IGNORECASE))
 
 
 class BaseTool(ABC):

--- a/ralph_pp/tools/cli_tool.py
+++ b/ralph_pp/tools/cli_tool.py
@@ -91,7 +91,8 @@ class CliTool(BaseTool):
             console.print("[dim]" + result.stderr + "[/dim]")
 
         return ToolResult(
-            output=result.stdout + result.stderr,
+            output=result.stdout,
             exit_code=result.returncode,
             success=result.returncode == 0,
+            stderr=result.stderr,
         )

--- a/tests/test_lgtm.py
+++ b/tests/test_lgtm.py
@@ -1,10 +1,10 @@
-"""Tests for ToolResult.is_lgtm exact-match semantics."""
+"""Tests for ToolResult.is_lgtm semantics."""
 
 from ralph_pp.tools.base import ToolResult
 
 
-def _result(output: str) -> ToolResult:
-    return ToolResult(output=output, exit_code=0, success=True)
+def _result(output: str, stderr: str = "") -> ToolResult:
+    return ToolResult(output=output, exit_code=0, success=True, stderr=stderr)
 
 
 class TestIsLgtm:
@@ -29,9 +29,6 @@ class TestIsLgtm:
     def test_lgtm_substring_in_prose(self):
         assert _result("This is LGTM approved").is_lgtm is False
 
-    def test_lowercase_lgtm(self):
-        assert _result("lgtm").is_lgtm is False
-
     def test_empty_output(self):
         assert _result("").is_lgtm is False
 
@@ -40,3 +37,27 @@ class TestIsLgtm:
 
     def test_multiline_lgtm_not_first_line(self):
         assert _result("Reviewed changes.\nLGTM").is_lgtm is False
+
+    # ── Case-insensitive matching ──────────────────────────────────────
+
+    def test_lowercase_lgtm(self):
+        assert _result("lgtm").is_lgtm is True
+
+    def test_mixed_case_lgtm(self):
+        assert _result("Lgtm").is_lgtm is True
+
+    # ── Common model variations ────────────────────────────────────────
+
+    def test_lgtm_exclamation(self):
+        assert _result("LGTM!").is_lgtm is True
+
+    def test_lgtm_period(self):
+        assert _result("LGTM.").is_lgtm is True
+
+    # ── stderr must not interfere ──────────────────────────────────────
+
+    def test_lgtm_with_stderr_noise(self):
+        assert _result("LGTM", stderr="Warning: deprecated flag").is_lgtm is True
+
+    def test_stderr_containing_lgtm_doesnt_match(self):
+        assert _result("findings here", stderr="LGTM").is_lgtm is False


### PR DESCRIPTION
## Summary
- Separate `stdout` and `stderr` in `ToolResult` — `is_lgtm` now checks only stdout
- Make `is_lgtm` regex case-insensitive and tolerant of common variations (`LGTM!`, `lgtm`, `LGTM.`)
- Error messages in reviewer/fixer failure paths fall back to `stderr` when `stdout` is empty

## Test plan
- [x] All 16 `test_lgtm.py` tests pass (6 new tests for case-insensitivity, variations, and stderr isolation)
- [x] All 99 affected test files pass (`test_lgtm`, `test_cli_tool`, `test_prd`, `test_review_loops`, `test_sandbox_orchestrated`)
- [x] Lint and typecheck pass

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)