### PR TITLE
fix: report worktree path on failure instead of leaking (#9)

### DIFF
--- a/ralph_pp/orchestrator.py
+++ b/ralph_pp/orchestrator.py
@@ -52,6 +52,7 @@ class Orchestrator:
             return
 
         start_time = time.monotonic()
+        failed = False
         try:
             if prd_only:
                 self._step_prd_only(skip_prd_review, manual_prd=manual_prd)
@@ -66,8 +67,16 @@ class Orchestrator:
                 self._step_post_review()
             self._step_cleanup()
         except Exception as exc:
+            failed = True
             console.print("[bold red]\n✗ Workflow failed:[/bold red] " + str(exc))
             raise
+        finally:
+            if failed and self.worktree_path:
+                console.print(f"[yellow]Worktree preserved at:[/yellow] {self.worktree_path}")
+                console.print(f"[yellow]Branch:[/yellow] {self.branch}")
+                console.print(
+                    f"[dim]Clean up manually with: git worktree remove {self.worktree_path}[/dim]"
+                )
 
         elapsed = time.monotonic() - start_time
         self._print_summary(elapsed, skip_post_review)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,56 @@
+"""Tests for Orchestrator failure handling."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ralph_pp.orchestrator import Orchestrator
+
+
+class TestWorktreePreservedOnFailure:
+    """When the workflow fails after worktree creation, the worktree path and
+    branch should be reported but NOT deleted (to support future --resume)."""
+
+    def _make_orchestrator(self, tmp_path: Path) -> Orchestrator:
+        from ralph_pp.config import Config
+
+        cfg = Config.__new__(Config)
+        orch = Orchestrator("test-feature", cfg)
+        orch.worktree_path = tmp_path / "worktree"
+        orch.branch = "ralph/test-feature-abc123"
+        return orch
+
+    @patch.object(Orchestrator, "_step_cleanup")
+    @patch.object(Orchestrator, "_step_post_review")
+    @patch.object(Orchestrator, "_step_sandbox", side_effect=RuntimeError("docker crashed"))
+    @patch.object(Orchestrator, "_step_prd")
+    @patch.object(Orchestrator, "_step_worktree")
+    def test_worktree_path_reported_on_failure(
+        self, mock_wt, mock_prd, mock_sandbox, mock_post, mock_clean, tmp_path, capsys
+    ):
+        orch = self._make_orchestrator(tmp_path)
+
+        # _step_worktree sets worktree_path; simulate that
+        def set_worktree():
+            orch.worktree_path = tmp_path / "worktree"
+            orch.branch = "ralph/test-feature-abc123"
+
+        mock_wt.side_effect = set_worktree
+
+        with pytest.raises(RuntimeError, match="docker crashed"):
+            orch.run()
+
+        captured = capsys.readouterr().out
+        assert "Worktree preserved at:" in captured or str(tmp_path / "worktree") in captured
+
+    @patch.object(Orchestrator, "_step_worktree", side_effect=RuntimeError("git failed"))
+    def test_no_worktree_message_when_worktree_not_created(self, mock_wt, tmp_path, capsys):
+        orch = self._make_orchestrator(tmp_path)
+        orch.worktree_path = None  # not yet created
+
+        with pytest.raises(RuntimeError, match="git failed"):
+            orch.run()
+
+        captured = capsys.readouterr().out
+        assert "Worktree preserved" not in captured


### PR DESCRIPTION
## Summary
- Add `finally` block to `Orchestrator.run()` that prints the worktree path, branch, and cleanup command when the workflow fails after worktree creation
- Worktree is intentionally **preserved** (not deleted) to support future `--resume-worktree` capability (#20)
- No message when failure occurs before worktree creation

## Test plan
- [x] New `test_orchestrator.py` with 2 tests: failure after worktree creation reports path, failure before worktree creation stays quiet
- [x] Lint and typecheck pass

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)