### PR TITLE
fix: review scope wrong when no story completed but changes exist (#13)

### DIFF
--- a/ralph_pp/steps/sandbox.py
+++ b/ralph_pp/steps/sandbox.py
@@ -689,15 +689,17 @@ def _run_orchestrated(worktree_path: Path, config: Config) -> bool:
                         _backout_to(worktree_path, pre_sha, restore_files=restore_files)
                         continue
 
-            # Review changes — scope to newly-completed stories only
-            stories_text = (
-                format_stories(prd_json, newly_completed)
-                if newly_completed
-                else format_stories(
-                    prd_json,
-                    {sid for sid, p in curr_story_status.items() if not p},
+            # Review changes — scope to newly-completed stories only.
+            # When no story was marked complete, tell the reviewer to
+            # evaluate the diff on its own rather than scoping to all
+            # incomplete stories (which would be noisy and misleading).
+            if newly_completed:
+                stories_text = format_stories(prd_json, newly_completed)
+            else:
+                stories_text = (
+                    "(The coder made changes but did not mark any story "
+                    "as complete. Review the diff on its own merits.)"
                 )
-            )
             diff = _get_diff(worktree_path, pre_sha)
             review = _review_iteration(
                 iteration,

--- a/tests/test_sandbox_orchestrated.py
+++ b/tests/test_sandbox_orchestrated.py
@@ -1768,3 +1768,41 @@ class TestStoryScopedReview:
 
         with pytest.raises(PrdParseError, match="missing 'userStories' key"):
             read_story_status(prd_json)
+
+    def test_no_story_completed_uses_fallback_scope(self, tmp_path):
+        """When coder makes changes but marks no story complete, the reviewer
+        should get a fallback note instead of all incomplete stories."""
+        worktree = _setup_worktree(tmp_path)
+        config = _make_config(
+            tmp_path, max_iterations=1, max_iteration_retries=0, backout_on_failure=False
+        )
+
+        captured_stories_arg = None
+
+        def mock_subprocess_run(cmd, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd:
+                return _fake_subprocess_run(returncode=0, stdout="abc1234")
+            if isinstance(cmd, list) and "diff" in cmd:
+                return _fake_subprocess_run(returncode=0, stdout="some diff")
+            # Coder runs but does NOT update prd.json — no story marked complete
+            return _fake_subprocess_run(returncode=0, stdout="coder output")
+
+        def mock_review(*args, **kwargs):
+            nonlocal captured_stories_arg
+            captured_stories_arg = kwargs.get("stories_under_review", "")
+            return ReviewResult(passed=True, findings="LGTM", max_severity=None, minor_only=True)
+
+        with (
+            patch("ralph_pp.steps.sandbox.subprocess.run", side_effect=mock_subprocess_run),
+            patch("ralph_pp.steps.sandbox._review_iteration", side_effect=mock_review),
+            patch("ralph_pp.steps.sandbox._commit_if_dirty", return_value=False),
+            patch("ralph_pp.steps.sandbox._get_head_sha", side_effect=_incrementing_sha()),
+            patch(
+                "ralph_pp.steps.sandbox._session_runner_path",
+                return_value=tmp_path / "scripts" / "ralph-single-step.sh",
+            ),
+        ):
+            _run_orchestrated(worktree, config)
+
+        assert captured_stories_arg is not None
+        assert "did not mark any story" in captured_stories_arg


### PR DESCRIPTION
## Summary
- When the coder makes changes but doesn't mark any story complete, the reviewer now gets a fallback note instead of being scoped to ALL incomplete stories
- Prevents noisy false findings about stories not yet attempted

## Test plan
- [x] New test: `test_no_story_completed_uses_fallback_scope`
- [x] All 49 orchestrated sandbox tests pass
- [x] Lint and typecheck pass

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)