### PR TITLE
fix: warn on unsubstituted prompt template placeholders (#12)

### DIFF
--- a/ralph_pp/steps/sandbox.py
+++ b/ralph_pp/steps/sandbox.py
@@ -8,6 +8,8 @@ Supports two modes:
 from __future__ import annotations
 
 import json
+import logging
+import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -27,6 +29,7 @@ from ._git import (
     run_test_commands_with_output,
 )
 
+logger = logging.getLogger(__name__)
 console = Console()
 
 _ORCHESTRATED_CODER_PROMPT = """\
@@ -251,11 +254,27 @@ def _backout_to(
             path.write_text(content)
 
 
+_PLACEHOLDER_RE = re.compile(r"\{(\w+)\}")
+
+
 def _render_prompt(template: str, **kwargs: str) -> str:
-    """Substitute placeholders in a prompt template."""
+    """Substitute placeholders in a prompt template.
+
+    Warns about any ``{placeholder}`` tokens that were not substituted,
+    since a typo (e.g. ``{diff_output}`` instead of ``{diff}``) would
+    silently pass the literal token to the model.
+    """
     result = template
     for key, value in kwargs.items():
         result = result.replace("{" + key + "}", value)
+
+    remaining = _PLACEHOLDER_RE.findall(result)
+    if remaining:
+        logger.warning(
+            "Prompt template has unsubstituted placeholders: %s (available: %s)",
+            ", ".join(f"{{{p}}}" for p in remaining),
+            ", ".join(f"{{{k}}}" for k in kwargs),
+        )
     return result
 
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -116,11 +116,16 @@ def test_render_prompt():
     assert result == "Review my diff against /path/prd.json"
 
 
-def test_render_prompt_missing_placeholder():
-    """Missing placeholders are left as-is."""
+def test_render_prompt_missing_placeholder(caplog):
+    """Missing placeholders are left as-is and a warning is emitted."""
+    import logging
+
     template = "Review {diff} and {unknown}"
-    result = _render_prompt(template, diff="changes")
+    with caplog.at_level(logging.WARNING, logger="ralph_pp.steps.sandbox"):
+        result = _render_prompt(template, diff="changes")
     assert result == "Review changes and {unknown}"
+    assert "unsubstituted placeholders" in caplog.text
+    assert "{unknown}" in caplog.text
 
 
 def test_delegated_mode_integration(tmp_path):


### PR DESCRIPTION
## Summary
- `_render_prompt` now emits a `logger.warning` when any `{placeholder}` tokens remain after substitution
- Warning includes both the unsubstituted placeholders and the available keys, making typos easy to diagnose

## Test plan
- [x] Updated `test_render_prompt_missing_placeholder` to verify warning is emitted
- [x] All 7 sandbox tests pass
- [x] Lint and typecheck pass

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)