### PR TITLE
fix: post_review_loop ignores run_tests_between_steps (#14)

### DIFF
--- a/ralph_pp/steps/post_review.py
+++ b/ralph_pp/steps/post_review.py
@@ -106,9 +106,11 @@ def post_review_loop(worktree_path: Path, config: Config) -> PostReviewResult:
             else:
                 guidance = ""
 
-            # Pre-run tests so the reviewer gets concrete results
+            # Pre-run tests so the reviewer gets concrete results.
+            # Respect run_tests_between_steps — if the user disabled tests
+            # during orchestrated iterations, skip them here too (#14).
             test_results_text = ""
-            if test_cmds:
+            if test_cmds and config.orchestrated.run_tests_between_steps:
                 console.print("  [dim]Running test commands before review...[/dim]")
                 tests_ok, test_output = run_test_commands_with_output(worktree_path, test_cmds)
                 status_str = "PASSED" if tests_ok else "FAILED"

--- a/tests/test_review_loops.py
+++ b/tests/test_review_loops.py
@@ -592,3 +592,98 @@ class TestPostReviewDiff:
             "prompt", reviewer_mock.run.call_args[0][0] if reviewer_mock.run.call_args[0] else ""
         )
         assert "all changes since run start" not in prompt
+
+
+class TestPostReviewRespectsTestFlag:
+    """Post-review loop must respect run_tests_between_steps flag (#14)."""
+
+    def test_tests_skipped_when_flag_false(self, tmp_path):
+        from ralph_pp.config import OrchestratedConfig
+
+        config = _make_config(
+            post_review=PostReviewConfig(
+                reviewer="codex",
+                fixer="claude",
+                max_cycles=1,
+            ),
+        )
+        config.orchestrated = OrchestratedConfig(
+            test_commands=["pytest"],
+            run_tests_between_steps=False,
+        )
+
+        prd_json = tmp_path / "scripts" / "ralph" / "prd.json"
+        prd_json.parent.mkdir(parents=True)
+        prd_json.write_text('{"userStories": []}')
+
+        with (
+            patch("ralph_pp.steps.post_review.make_tool") as mock_make,
+            patch("ralph_pp.steps.post_review.make_tool_with_permissions") as mock_make_aug,
+            patch("ralph_pp.steps.post_review.prompt_max_cycles", return_value="quit"),
+            patch("ralph_pp.steps.post_review.get_head_sha", return_value="abc1234"),
+            patch("ralph_pp.steps.post_review.get_diff", return_value="(no diff)"),
+            patch(
+                "ralph_pp.steps.post_review.run_test_commands_with_output",
+            ) as mock_run_tests,
+        ):
+            reviewer_mock = MagicMock()
+            reviewer_mock.run.return_value = _ok_result("1. severity: minor\nfoo")
+            fixer_mock = MagicMock()
+            fixer_mock.run.return_value = _ok_result("fixed")
+            mock_make.side_effect = lambda name, cfg: (
+                reviewer_mock if name == "codex" else fixer_mock
+            )
+            mock_make_aug.side_effect = lambda name, cfg, cmds: (
+                reviewer_mock if name == "codex" else fixer_mock
+            )
+
+            with pytest.raises(MaxCyclesAbort):
+                post_review_loop(tmp_path, config)
+
+        mock_run_tests.assert_not_called()
+
+    def test_tests_run_when_flag_true(self, tmp_path):
+        from ralph_pp.config import OrchestratedConfig
+
+        config = _make_config(
+            post_review=PostReviewConfig(
+                reviewer="codex",
+                fixer="claude",
+                max_cycles=1,
+            ),
+        )
+        config.orchestrated = OrchestratedConfig(
+            test_commands=["pytest"],
+            run_tests_between_steps=True,
+        )
+
+        prd_json = tmp_path / "scripts" / "ralph" / "prd.json"
+        prd_json.parent.mkdir(parents=True)
+        prd_json.write_text('{"userStories": []}')
+
+        with (
+            patch("ralph_pp.steps.post_review.make_tool") as mock_make,
+            patch("ralph_pp.steps.post_review.make_tool_with_permissions") as mock_make_aug,
+            patch("ralph_pp.steps.post_review.prompt_max_cycles", return_value="quit"),
+            patch("ralph_pp.steps.post_review.get_head_sha", return_value="abc1234"),
+            patch("ralph_pp.steps.post_review.get_diff", return_value="(no diff)"),
+            patch(
+                "ralph_pp.steps.post_review.run_test_commands_with_output",
+                return_value=(True, "all passed"),
+            ) as mock_run_tests,
+        ):
+            reviewer_mock = MagicMock()
+            reviewer_mock.run.return_value = _ok_result("1. severity: minor\nfoo")
+            fixer_mock = MagicMock()
+            fixer_mock.run.return_value = _ok_result("fixed")
+            mock_make.side_effect = lambda name, cfg: (
+                reviewer_mock if name == "codex" else fixer_mock
+            )
+            mock_make_aug.side_effect = lambda name, cfg, cmds: (
+                reviewer_mock if name == "codex" else fixer_mock
+            )
+
+            with pytest.raises(MaxCyclesAbort):
+                post_review_loop(tmp_path, config)
+
+        mock_run_tests.assert_called()


### PR DESCRIPTION
## Summary
- Post-review loop now gates test execution on `run_tests_between_steps`, consistent with orchestrated iterations
- Users who set `run_tests_between_steps: false` will no longer get surprise test runs in the post-review phase

## Test plan
- [x] New tests: `test_tests_skipped_when_flag_false` and `test_tests_run_when_flag_true`
- [x] All 22 review loop tests pass
- [x] Lint and typecheck pass

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)