### PR TITLE
fix: CLI always overrides config repo_path with cwd (#33)

### DIFF
--- a/ralph_pp/cli.py
+++ b/ralph_pp/cli.py
@@ -72,8 +72,6 @@ def _build_overrides(
     overrides: dict[str, Any] = {}
     if repo:
         overrides["repo_path"] = repo
-    elif repo is None:
-        overrides["repo_path"] = Path.cwd()
     if claude_config:
         overrides["claude_config_dir"] = claude_config
     if codex_config:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,21 @@
+"""Tests for CLI helpers."""
+
+from pathlib import Path
+
+from ralph_pp.cli import _build_overrides
+
+
+class TestBuildOverrides:
+    def test_repo_explicit(self, tmp_path: Path):
+        overrides = _build_overrides(
+            repo=tmp_path, claude_config=None, codex_config=None, sandbox_dir=None
+        )
+        assert overrides["repo_path"] == tmp_path
+
+    def test_repo_none_does_not_override(self):
+        """When --repo is not passed, repo_path should NOT be in overrides
+        so that config-file values are preserved (#33)."""
+        overrides = _build_overrides(
+            repo=None, claude_config=None, codex_config=None, sandbox_dir=None
+        )
+        assert "repo_path" not in overrides


### PR DESCRIPTION
## Summary
- Remove the `elif repo is None: overrides["repo_path"] = Path.cwd()` branch from `_build_overrides()`
- Config-file `repo_path` values are now respected when `--repo` is not passed
- The `Config` dataclass default (`Path.cwd`) provides the fallback when neither source sets it

## Test plan
- [x] New tests: `test_repo_explicit` and `test_repo_none_does_not_override`
- [x] Lint and typecheck pass

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)