### PR TITLE
fix: worktree path conflict check before creation (#19)

### DIFF
--- a/ralph_pp/steps/worktree.py
+++ b/ralph_pp/steps/worktree.py
@@ -28,9 +28,19 @@ def create_worktree(feature: str, config: Config) -> tuple[Path, str]:
     Returns:
         (worktree_path, branch_name)
     """
-    branch = make_branch_name(feature, config)
-    # Place worktree as a sibling of the repo directory
-    worktree_path = config.repo_path.parent / branch.replace("/", "-")
+    # Try up to a few times in case the generated path already exists
+    # (e.g. from a previous failed run with the same random suffix).
+    branch = ""
+    worktree_path = Path()
+    for _attempt in range(5):
+        branch = make_branch_name(feature, config)
+        worktree_path = config.repo_path.parent / branch.replace("/", "-")
+        if not worktree_path.exists():
+            break
+    else:
+        raise RuntimeError(
+            f"Could not find a free worktree path after 5 attempts (last tried: {worktree_path})"
+        )
 
     console.print(f"[bold]Creating worktree:[/bold] {worktree_path}")
     console.print(f"[bold]Branch:[/bold] {branch}")

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -1,7 +1,10 @@
-"""Tests for branch name generation."""
+"""Tests for branch name generation and worktree creation."""
+
+from pathlib import Path
+from unittest.mock import patch
 
 from ralph_pp.config import load_config
-from ralph_pp.steps.worktree import make_branch_name
+from ralph_pp.steps.worktree import create_worktree, make_branch_name
 
 
 def test_branch_name_slugified():
@@ -28,3 +31,33 @@ def test_branch_name_special_chars():
     assert "@" not in name
     assert "!" not in name
     assert ":" not in name
+
+
+class TestWorktreeConflictCheck:
+    def test_retries_when_path_exists(self, tmp_path: Path):
+        """If the generated worktree path already exists, a new suffix is tried."""
+        cfg = load_config(None)
+        cfg.repo_path = tmp_path / "repo"
+        cfg.repo_path.mkdir()
+
+        call_count = 0
+        original_make = make_branch_name
+
+        def mock_make(feature, config):
+            nonlocal call_count
+            call_count += 1
+            branch = original_make(feature, config)
+            if call_count == 1:
+                # Pre-create the directory to simulate a conflict
+                conflict = config.repo_path.parent / branch.replace("/", "-")
+                conflict.mkdir(parents=True, exist_ok=True)
+            return branch
+
+        with (
+            patch("ralph_pp.steps.worktree.make_branch_name", side_effect=mock_make),
+            patch("ralph_pp.steps.worktree.subprocess.run"),
+        ):
+            path, branch = create_worktree("test feature", cfg)
+
+        assert call_count >= 2, "Should have retried after conflict"
+        assert not path.exists() or call_count > 1


### PR DESCRIPTION
## Summary
- `create_worktree` now checks if the generated path already exists before calling `git worktree add`
- Retries with a new random suffix up to 5 times, raises `RuntimeError` if all attempts conflict

## Test plan
- [x] New test: `test_retries_when_path_exists`
- [x] All 4 worktree tests pass
- [x] Lint and typecheck pass

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)