### PR TITLE
fix: validate session runner path before worktree creation (#16)

### DIFF
--- a/ralph_pp/orchestrator.py
+++ b/ralph_pp/orchestrator.py
@@ -20,7 +20,7 @@ from .steps.prd import (
     generate_prd,
     review_prd_loop,
 )
-from .steps.sandbox import RunSummary, run_sandbox
+from .steps.sandbox import RunSummary, run_sandbox, validate_sandbox_prerequisites
 from .steps.worktree import cleanup_git_config, create_worktree
 
 console = Console()
@@ -57,6 +57,9 @@ class Orchestrator:
             if prd_only:
                 self._step_prd_only(skip_prd_review, manual_prd=manual_prd)
                 return
+            # Validate sandbox prerequisites before creating the worktree
+            # so we fail fast on misconfiguration (#16).
+            validate_sandbox_prerequisites(self.config)
             self._step_worktree()
             if prd_file is not None:
                 self._step_prd_from_file(prd_file)

--- a/ralph_pp/steps/sandbox.py
+++ b/ralph_pp/steps/sandbox.py
@@ -117,6 +117,20 @@ class RunSummary:
     retries: int  # total backout retries or fix cycles
 
 
+def validate_sandbox_prerequisites(config: Config) -> None:
+    """Validate sandbox configuration before expensive workflow steps.
+
+    Call this early (before worktree creation) so misconfigurations
+    fail fast instead of minutes into the workflow.
+    """
+    # Validate sandbox directory resolves
+    resolve_sandbox_dir(config)
+
+    # Validate session runner exists (orchestrated mode only)
+    if config.ralph.mode == "orchestrated":
+        _session_runner_path(config)
+
+
 def run_sandbox(worktree_path: Path, config: Config) -> RunSummary:
     """Run the Ralph loop. Dispatches to delegated or orchestrated mode.
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -26,8 +26,17 @@ class TestWorktreePreservedOnFailure:
     @patch.object(Orchestrator, "_step_sandbox", side_effect=RuntimeError("docker crashed"))
     @patch.object(Orchestrator, "_step_prd")
     @patch.object(Orchestrator, "_step_worktree")
+    @patch("ralph_pp.orchestrator.validate_sandbox_prerequisites")
     def test_worktree_path_reported_on_failure(
-        self, mock_wt, mock_prd, mock_sandbox, mock_post, mock_clean, tmp_path, capsys
+        self,
+        mock_validate,
+        mock_wt,
+        mock_prd,
+        mock_sandbox,
+        mock_post,
+        mock_clean,
+        tmp_path,
+        capsys,
     ):
         orch = self._make_orchestrator(tmp_path)
 
@@ -45,7 +54,10 @@ class TestWorktreePreservedOnFailure:
         assert "Worktree preserved at:" in captured or str(tmp_path / "worktree") in captured
 
     @patch.object(Orchestrator, "_step_worktree", side_effect=RuntimeError("git failed"))
-    def test_no_worktree_message_when_worktree_not_created(self, mock_wt, tmp_path, capsys):
+    @patch("ralph_pp.orchestrator.validate_sandbox_prerequisites")
+    def test_no_worktree_message_when_worktree_not_created(
+        self, mock_validate, mock_wt, tmp_path, capsys
+    ):
         orch = self._make_orchestrator(tmp_path)
         orch.worktree_path = None  # not yet created
 


### PR DESCRIPTION
## Summary
- New `validate_sandbox_prerequisites()` function checks sandbox dir and session runner path
- Called at the start of `Orchestrator.run()`, before `_step_worktree()`
- Misconfigured session runner now fails in seconds, not minutes into the workflow

## Test plan
- [x] All 60 orchestrator + sandbox tests pass
- [x] Lint and typecheck pass

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)