### PR TITLE
refactor: use Literal types for mode and severity threshold (#15)

### DIFF
--- a/ralph_pp/cli.py
+++ b/ralph_pp/cli.py
@@ -13,6 +13,7 @@ from .config import (
     format_effective_config,
     load_config,
     load_config_with_provenance,
+    parse_mode,
 )
 from .orchestrator import Orchestrator
 
@@ -227,7 +228,7 @@ def run(
     if max_iters is not None:
         cfg.ralph.max_iterations = max_iters
     if mode is not None:
-        cfg.ralph.mode = mode  # type: ignore[assignment]  # validated by Click choice
+        cfg.ralph.mode = parse_mode(mode)
     if setup_cmd:
         existing = cfg.hooks.get("post_worktree_create", [])
         cfg.hooks["post_worktree_create"] = list(setup_cmd) + existing

--- a/ralph_pp/config.py
+++ b/ralph_pp/config.py
@@ -231,10 +231,31 @@ class PostReviewConfig(ReviewConfig):
     fixer_prompt: str = _POST_FIXER_PROMPT
 
 
+Mode = Literal["delegated", "orchestrated"]
+Severity = Literal["minor", "major", "critical"]
+
+_VALID_MODES: set[str] = {"delegated", "orchestrated"}
+_VALID_SEVERITIES: set[str] = {"minor", "major", "critical"}
+
+
+def parse_mode(value: str) -> Mode:
+    """Validate and narrow a string to a ``Mode`` literal."""
+    if value not in _VALID_MODES:
+        raise ValueError(f"Invalid mode: {value!r} (expected one of {_VALID_MODES})")
+    return cast(Mode, value)
+
+
+def parse_severity(value: str) -> Severity:
+    """Validate and narrow a string to a ``Severity`` literal."""
+    if value not in _VALID_SEVERITIES:
+        raise ValueError(f"Invalid severity: {value!r} (expected one of {_VALID_SEVERITIES})")
+    return cast(Severity, value)
+
+
 @dataclass
 class RalphConfig:
     max_iterations: int = 20
-    mode: Literal["delegated", "orchestrated"] = "delegated"
+    mode: Mode = "delegated"
     sandbox_dir: str = ""  # path to ralph-sandbox checkout
     sandbox_tool: str = "claude"  # tool for sandbox (delegated mode): claude | codex
     session_runner: str = "scripts/ralph-single-step.sh"  # session runner for orchestrated mode
@@ -249,7 +270,7 @@ class OrchestratedConfig:
     run_tests_between_steps: bool = False
     test_commands: list[str] = field(default_factory=lambda: list[str]())
     backout_on_failure: bool = True
-    backout_severity_threshold: Literal["minor", "major", "critical"] = "major"
+    backout_severity_threshold: Severity = "major"
     auto_allow_test_commands: bool = True
     max_idle_iterations: int = 2
     review_prompt: str = _ORCHESTRATED_REVIEW_PROMPT
@@ -529,7 +550,7 @@ def _build_config(data: dict[str, Any]) -> Config:
         r = data["ralph"]
         cfg.ralph = RalphConfig(
             max_iterations=int(r.get("max_iterations", 20)),
-            mode=r.get("mode", "delegated"),
+            mode=parse_mode(r.get("mode", "delegated")),
             sandbox_dir=r.get("sandbox_dir", ""),
             sandbox_tool=r.get("sandbox_tool", "claude"),
             session_runner=r.get("session_runner", "scripts/ralph-single-step.sh"),
@@ -554,8 +575,8 @@ def _build_config(data: dict[str, Any]) -> Config:
                 o.get("backout_on_failure", defaults.backout_on_failure),
                 defaults.backout_on_failure,
             ),
-            backout_severity_threshold=o.get(
-                "backout_severity_threshold", defaults.backout_severity_threshold
+            backout_severity_threshold=parse_severity(
+                o.get("backout_severity_threshold", defaults.backout_severity_threshold)
             ),
             auto_allow_test_commands=_parse_bool(
                 o.get("auto_allow_test_commands", defaults.auto_allow_test_commands),
@@ -604,9 +625,8 @@ def validate_config(cfg: Config) -> None:
     """Validate config values that would otherwise cause confusing runtime errors."""
     errors: list[str] = []
 
-    valid_modes = {"delegated", "orchestrated"}
-    if cfg.ralph.mode not in valid_modes:
-        errors.append(f"ralph.mode={cfg.ralph.mode!r} not in {valid_modes}")
+    if cfg.ralph.mode not in _VALID_MODES:
+        errors.append(f"ralph.mode={cfg.ralph.mode!r} not in {_VALID_MODES}")
 
     if cfg.prd_tool not in cfg.tools:
         errors.append(f"prd_tool={cfg.prd_tool!r} not in tools {list(cfg.tools)}")
@@ -637,11 +657,10 @@ def validate_config(cfg: Config) -> None:
         if review_cfg.fixer not in cfg.tools:
             errors.append(f"{stage_name}.fixer={review_cfg.fixer!r} not in tools {list(cfg.tools)}")
 
-    valid_severities = {"minor", "major", "critical"}
-    if cfg.orchestrated.backout_severity_threshold not in valid_severities:
+    if cfg.orchestrated.backout_severity_threshold not in _VALID_SEVERITIES:
         errors.append(
             f"orchestrated.backout_severity_threshold="
-            f"{cfg.orchestrated.backout_severity_threshold!r} not in {valid_severities}"
+            f"{cfg.orchestrated.backout_severity_threshold!r} not in {_VALID_SEVERITIES}"
         )
 
     if not isinstance(cfg.orchestrated.test_commands, list):


### PR DESCRIPTION
## Summary
- `RalphConfig.mode` → `Literal["delegated", "orchestrated"]`
- `OrchestratedConfig.backout_severity_threshold` → `Literal["minor", "major", "critical"]`
- Pyright can now catch invalid values at the call site; runtime validation still in place for YAML

## Test plan
- [x] All 57 config/cli tests pass
- [x] Lint and typecheck pass

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)