### PR TITLE
feat: add post_failure hook for run notifications (#22)

### DIFF
--- a/ralph_pp/orchestrator.py
+++ b/ralph_pp/orchestrator.py
@@ -77,6 +77,10 @@ class Orchestrator:
                 console.print(
                     f"[dim]Clean up manually with: git worktree remove {self.worktree_path}[/dim]"
                 )
+                try:
+                    run_hooks("post_failure", self.config.hooks, self.worktree_path)
+                except Exception:
+                    pass  # Don't mask the original error
 
         elapsed = time.monotonic() - start_time
         self._print_summary(elapsed, skip_post_review)


### PR DESCRIPTION
## Summary
- New `post_failure` hook runs when the workflow fails after worktree creation
- Together with the existing `post_complete` hook, enables notifications for both outcomes
- Error in the hook itself is swallowed to avoid masking the original failure

## Test plan
- [x] All 2 orchestrator tests pass
- [x] Lint and typecheck pass

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)