### PR TITLE
fix: move import os to module level (#29)

### DIFF
--- a/ralph_pp/steps/sandbox.py
+++ b/ralph_pp/steps/sandbox.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import subprocess
 from dataclasses import dataclass
@@ -526,8 +527,6 @@ def _run_fixer_in_sandbox(
 
 def _merge_env(extra: dict[str, str]) -> dict[str, str]:
     """Merge extra env vars into a copy of the current environment."""
-    import os
-
     env = os.environ.copy()
     env.update(extra)
     return env


### PR DESCRIPTION
Trivial fix — moves `import os` from function-level in `_merge_env` to the top of the module.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)