### PR TITLE
fix: cleanup_git_config removes all hook-added keys (#28)

### DIFF
--- a/ralph_pp/orchestrator.py
+++ b/ralph_pp/orchestrator.py
@@ -21,7 +21,7 @@ from .steps.prd import (
     review_prd_loop,
 )
 from .steps.sandbox import RunSummary, run_sandbox, validate_sandbox_prerequisites
-from .steps.worktree import cleanup_git_config, create_worktree
+from .steps.worktree import cleanup_git_config, create_worktree, snapshot_local_config
 
 console = Console()
 
@@ -33,6 +33,7 @@ class Orchestrator:
         self.dry_run = dry_run
         self.worktree_path: Path | None = None
         self.branch: str | None = None
+        self._baseline_config_keys: set[str] | None = None
         self._run_summary: RunSummary | None = None
         self._review_result: PostReviewResult | None = None
 
@@ -95,6 +96,8 @@ class Orchestrator:
     def _step_worktree(self) -> None:
         console.print(Rule("[bold]1 · Worktree[/bold]"))
         self.worktree_path, self.branch = create_worktree(self.feature, self.config)
+        # Snapshot local config before hooks run, so cleanup can diff later
+        self._baseline_config_keys = snapshot_local_config(self.worktree_path)
         run_hooks("post_worktree_create", self.config.hooks, self.worktree_path)
 
     def _step_prd_only(self, skip_review: bool, *, manual_prd: bool = False) -> None:
@@ -161,7 +164,7 @@ class Orchestrator:
     def _step_cleanup(self) -> None:
         assert self.worktree_path is not None
         console.print(Rule("[bold]5 · Cleanup[/bold]"))
-        cleanup_git_config(self.worktree_path)
+        cleanup_git_config(self.worktree_path, self._baseline_config_keys)
         run_hooks("post_complete", self.config.hooks, self.worktree_path)
 
     def _print_summary(self, elapsed: float, skip_post_review: bool) -> None:

--- a/ralph_pp/steps/worktree.py
+++ b/ralph_pp/steps/worktree.py
@@ -56,27 +56,50 @@ def create_worktree(feature: str, config: Config) -> tuple[Path, str]:
     return worktree_path, branch
 
 
-def cleanup_git_config(worktree_path: Path) -> None:
-    """Remove any locally set git user config from the worktree."""
+def snapshot_local_config(worktree_path: Path) -> set[str]:
+    """Return the set of local git config keys present in the worktree."""
+    result = subprocess.run(
+        ["git", "config", "--local", "--list"],
+        cwd=worktree_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    keys: set[str] = set()
+    for line in result.stdout.splitlines():
+        key, _, _ = line.partition("=")
+        if key:
+            keys.add(key)
+    return keys
+
+
+def cleanup_git_config(worktree_path: Path, baseline_keys: set[str] | None = None) -> None:
+    """Remove locally set git config keys that were added after worktree creation.
+
+    If *baseline_keys* is provided, unsets any local key not in the
+    baseline. Otherwise falls back to unsetting user.name and user.email.
+    """
     console.print("[bold]Cleaning up git config...[/bold]")
-    for key in ("user.name", "user.email"):
-        subprocess.run(
-            ["git", "config", "--unset", key],
+
+    current_keys = snapshot_local_config(worktree_path)
+    keys_to_remove: set[str] = set()
+    if baseline_keys is not None:
+        keys_to_remove = current_keys - baseline_keys
+    # Always include user.name/email for backward compatibility
+    keys_to_remove |= current_keys & {"user.name", "user.email"}
+
+    removed = 0
+    for key in sorted(keys_to_remove):
+        result = subprocess.run(
+            ["git", "config", "--local", "--unset", key],
             cwd=worktree_path,
-            # unset returns exit 5 if key not set — that is fine
             check=False,
             text=True,
         )
-    # Verify
-    result = subprocess.run(
-        ["git", "config", "--list"],
-        cwd=worktree_path,
-        check=True,
-        text=True,
-        capture_output=True,
-    )
-    user_lines = [line for line in result.stdout.splitlines() if line.startswith("user.")]
-    if user_lines:
-        console.print(f"[yellow]Remaining user config:[/yellow] {user_lines}")
+        if result.returncode == 0:
+            removed += 1
+
+    if removed:
+        console.print(f"[green]✓ Removed {removed} local git config key(s)[/green]")
     else:
-        console.print("[green]✓ Git user config clean[/green]")
+        console.print("[green]✓ No local git config to clean up[/green]")


### PR DESCRIPTION
## Summary
- `snapshot_local_config()` captures local git config keys at worktree creation time
- `cleanup_git_config()` now diffs against the baseline and unsets anything added by hooks
- `user.name`/`user.email` always cleaned for backward compatibility

## Test plan
- [x] All 6 worktree/orchestrator tests pass
- [x] Lint and typecheck pass

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)