### PR TITLE
fix: worktrees clean exits non-zero on partial failure

### DIFF
--- a/ralph_pp/cli.py
+++ b/ralph_pp/cli.py
@@ -401,6 +401,7 @@ def worktrees_clean(repo: Path | None, force: bool) -> None:
         console.print(f"[green]✓ Removed {removed} worktree(s)[/green]")
     if failed:
         console.print(f"[red]✗ Failed to remove {failed} worktree(s)[/red]")
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,3 +104,32 @@ class TestWorktreesClean:
         assert result.exit_code == 0
         assert "Removed 1 worktree" in result.output
         assert not wt.exists()
+
+    def test_clean_exits_nonzero_on_partial_failure(self, tmp_path: Path):
+        """When some worktrees fail to remove (dirty), exit code should be 1."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_repo(repo)
+
+        wt = tmp_path / "ralph-dirty-test"
+        subprocess.run(
+            ["git", "worktree", "add", "-b", "ralph/dirty-test", str(wt)],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+        # Make the worktree dirty so git refuses to remove it without --force
+        (wt / "untracked.txt").write_text("dirty")
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["worktrees", "clean", "--repo", str(repo), "--yes"])
+        assert result.exit_code == 1
+        assert "Failed to remove" in result.output
+
+        # Cleanup
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(wt)],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )


### PR DESCRIPTION
## Summary
- `worktrees clean` now exits with code 1 when any worktree removal fails
- Previously exited 0 even when most removals failed (e.g. 16 of 23 dirty worktrees)
- Added test for partial failure scenario

Closes #96

## Test plan
- [x] All 252 tests pass (1 new)
- [x] Lint and typecheck clean