### PR TITLE
fix: check template placeholders before substitution to avoid false positives

### DIFF
--- a/ralph_pp/steps/_prompts.py
+++ b/ralph_pp/steps/_prompts.py
@@ -13,19 +13,24 @@ _PLACEHOLDER_RE = re.compile(r"\{(\w+)\}")
 def render_prompt(template: str, **kwargs: str) -> str:
     """Substitute ``{placeholder}`` tokens in a prompt template.
 
-    Warns about any tokens that were not substituted, since a typo
-    (e.g. ``{diff_output}`` instead of ``{diff}``) would silently pass
-    the literal token to the model.
+    Warns about any placeholders present in the *original template* that
+    were not provided in *kwargs*.  This catches typos
+    (e.g. ``{diff_output}`` instead of ``{diff}``) without false-
+    positives from ``{word}`` patterns inside substituted content such
+    as code diffs.
     """
+    # Detect unknown placeholders from the template BEFORE substitution
+    # so that literals inside diff/code values are never scanned.
+    template_placeholders = set(_PLACEHOLDER_RE.findall(template))
+    unknown = template_placeholders - set(kwargs)
+    if unknown:
+        logger.warning(
+            "Prompt template has unsubstituted placeholders: %s (available: %s)",
+            ", ".join(f"{{{p}}}" for p in sorted(unknown)),
+            ", ".join(f"{{{k}}}" for k in sorted(kwargs)),
+        )
+
     result = template
     for key, value in kwargs.items():
         result = result.replace("{" + key + "}", value)
-
-    remaining = _PLACEHOLDER_RE.findall(result)
-    if remaining:
-        logger.warning(
-            "Prompt template has unsubstituted placeholders: %s (available: %s)",
-            ", ".join(f"{{{p}}}" for p in remaining),
-            ", ".join(f"{{{k}}}" for k in kwargs),
-        )
     return result

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -121,11 +121,23 @@ def testrender_prompt_missing_placeholder(caplog):
     import logging
 
     template = "Review {diff} and {unknown}"
-    with caplog.at_level(logging.WARNING, logger="ralph_pp.steps.sandbox"):
+    with caplog.at_level(logging.WARNING, logger="ralph_pp.steps._prompts"):
         result = render_prompt(template, diff="changes")
     assert result == "Review changes and {unknown}"
     assert "unsubstituted placeholders" in caplog.text
     assert "{unknown}" in caplog.text
+
+
+def testrender_prompt_no_false_positive_from_substituted_content(caplog):
+    """Placeholders inside substituted values should not trigger warnings."""
+    import logging
+
+    template = "Review this diff:\n{diff}"
+    diff_with_braces = 'def validate(ts):\n    raise ValueError(f"{param_name} must be UTC")'
+    with caplog.at_level(logging.WARNING, logger="ralph_pp.steps._prompts"):
+        result = render_prompt(template, diff=diff_with_braces)
+    assert "{param_name}" in result
+    assert "unsubstituted placeholders" not in caplog.text
 
 
 def test_delegated_mode_integration(tmp_path):


### PR DESCRIPTION
## Summary
- `render_prompt` now scans the original template for unknown placeholders *before* substitution
- Previously scanned the entire result (including substituted diffs/code), causing false warnings when code contained `{param_name}` style strings
- Added test proving substituted content with braces does not trigger warnings

Closes #91

## Test plan
- [x] All 252 tests pass (1 new)
- [x] Lint and typecheck clean
- [x] Existing missing-placeholder warning test updated and passing