### PR TITLE
fix: clean up orchestration artifacts before final commit

### DIFF
--- a/ralph_pp/orchestrator.py
+++ b/ralph_pp/orchestrator.py
@@ -23,7 +23,12 @@ from .steps.prd import (
     review_prd_loop,
 )
 from .steps.sandbox import RunSummary, run_sandbox, validate_sandbox_prerequisites
-from .steps.worktree import cleanup_git_config, create_worktree, snapshot_local_config
+from .steps.worktree import (
+    cleanup_git_config,
+    cleanup_orchestration_artifacts,
+    create_worktree,
+    snapshot_local_config,
+)
 
 console = Console()
 
@@ -215,6 +220,7 @@ class Orchestrator:
     def _step_cleanup(self) -> None:
         assert self.worktree_path is not None
         console.print(Rule("[bold]5 · Cleanup[/bold]"))
+        cleanup_orchestration_artifacts(self.worktree_path)
         cleanup_git_config(self.worktree_path, self._baseline_config_keys)
         run_hooks("post_complete", self.config.hooks, self.worktree_path)
 

--- a/ralph_pp/steps/worktree.py
+++ b/ralph_pp/steps/worktree.py
@@ -112,3 +112,38 @@ def cleanup_git_config(worktree_path: Path, baseline_keys: set[str] | None = Non
         console.print(f"[green]✓ Removed {removed} local git config key(s)[/green]")
     else:
         console.print("[green]✓ No local git config to clean up[/green]")
+
+
+# Internal orchestration files that should not appear in the final commit.
+_ORCHESTRATION_ARTIFACTS = [
+    "scripts/ralph/.base-sha",
+    "scripts/ralph/.fix-prompt.md",
+]
+
+
+def cleanup_orchestration_artifacts(worktree_path: Path) -> None:
+    """Remove internal orchestration files from the worktree and stage the deletions."""
+    removed = 0
+    for rel_path in _ORCHESTRATION_ARTIFACTS:
+        artifact = worktree_path / rel_path
+        if artifact.exists():
+            artifact.unlink()
+            removed += 1
+
+    if removed:
+        # Stage the deletions so the next commit (or amend) picks them up
+        subprocess.run(
+            ["git", "add", "-A", "scripts/ralph/"],
+            cwd=worktree_path,
+            check=False,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "ralph: remove orchestration artifacts"],
+            cwd=worktree_path,
+            check=False,
+            capture_output=True,
+        )
+        console.print(f"[green]✓ Removed {removed} orchestration artifact(s)[/green]")
+    else:
+        console.print("[green]✓ No orchestration artifacts to clean up[/green]")


### PR DESCRIPTION
## Summary
- Removes internal orchestration files (`.base-sha`, `.fix-prompt.md`) from `scripts/ralph/` during the cleanup step
- Creates a commit for the deletion so the artifacts don't appear in the final worktree state
- Runs before git config cleanup and post_complete hooks

Closes #101

## Test plan
- [x] All 251 tests pass
- [x] Lint and typecheck clean