### PR TITLE
feat: PRD feasibility checks and fix cycle resilience

### DIFF
--- a/ralph_pp/config.py
+++ b/ralph_pp/config.py
@@ -26,7 +26,27 @@ the project may require specific virtual environments or configurations."""
 _PRD_REVIEWER_PROMPT = """\
 Read the PRD at {prd_file}.
 
-Evaluate whether it is:
+Before evaluating the PRD as a document, perform a feasibility check
+against the actual codebase at {repo_path}:
+
+1. Identify every type, class, schema, or interface the PRD references
+   (e.g., dataclasses, Protocol classes, SQLite DDL, database models).
+2. Read the source files where those types are defined.
+3. For each field in the PRD's canonical contracts, verify:
+   - The corresponding field in the existing codebase type has a
+     compatible type (e.g., nullable vs non-nullable)
+   - Any schema constraints (NOT NULL, foreign keys, defaults) are
+     compatible with the PRD's stated behavioral guarantees
+   - The PRD's migration/compatibility claims (e.g., "no schema
+     migration needed") are true given the actual schema
+4. For each acceptance criterion that asserts exact round-trip behavior,
+   verify the underlying storage layer can represent all values in the
+   contract's type (e.g., can the column store NULL if the field is
+   Optional?)
+
+Flag any feasibility issue as severity: critical.
+
+Then evaluate the PRD as a document:
 - complete
 - unambiguous
 - implementable as a sequence of small independent user stories
@@ -67,6 +87,58 @@ Requirements:
 - do not add speculative scope that is not justified by the feature request or findings
 
 Do not output a summary instead of making the edits. Update the PRD itself."""
+
+_PRD_JSON_REVIEW_PROMPT = """\
+You are reviewing a generated prd.json against the original PRD and
+the codebase to catch criteria that were sharpened, invented, or made
+infeasible during the conversion from PRD markdown to structured JSON.
+
+Inputs:
+- Original PRD: {prd_file}
+- Generated prd.json: {prd_json_file}
+- Codebase root: {repo_path}
+
+For each user story in prd.json:
+
+1. **Traceability**: Verify every acceptance criterion traces back to
+   a requirement in the original PRD. Flag any criterion that was
+   invented during conversion and has no basis in the PRD.
+
+2. **Faithfulness**: Verify the criterion accurately represents the
+   PRD's intent. Flag any criterion that tightens a constraint beyond
+   what the PRD specifies (e.g., "all fields match exactly" when the
+   PRD allows semantic equivalence for certain fields).
+
+3. **Feasibility**: For criteria that reference codebase types or
+   schemas, verify the criterion is satisfiable given the actual types.
+   Read the relevant source files if needed.
+
+4. **Independence**: Verify the story can be implemented without
+   depending on stories with higher priority numbers.
+
+If prd.json is faithful, feasible, and traceable, output exactly:
+LGTM
+
+Otherwise, output a numbered list of issues.
+
+For each issue include:
+- severity: critical | major | minor
+- story: the story ID (e.g., US-004)
+- criterion: the specific acceptance criterion
+- problem: what is wrong
+- recommended fix: how to adjust the criterion in prd.json
+
+Do not rewrite prd.json yourself. Only review it."""
+
+_PRD_JSON_FIXER_PROMPT = """\
+Fix the following issues in {prd_json_file} based on the original PRD
+at {prd_file}.
+
+{findings}
+
+Update prd.json in place. Do not modify the PRD markdown.
+Only adjust acceptance criteria to resolve the flagged issues.
+Preserve story IDs, priorities, and overall structure."""
 
 _POST_REVIEWER_PROMPT = """\
 Review the implementation against ONLY the completed user stories listed below.
@@ -196,6 +268,53 @@ Requirements:
 If some finding is invalid or already resolved, handle that
 conservatively and focus on the remaining real issues."""
 
+_ORCHESTRATED_REVIEW_FIRST_PROMPT = """\
+Review the latest iteration against ONLY the user stories listed below.
+Do NOT evaluate against stories that are not listed here.
+
+## Stories under review
+
+{stories_under_review}
+
+## Feasibility pre-check
+
+Before reviewing the diff, check whether each acceptance criterion above
+is structurally satisfiable:
+1. Read the original types/schemas of the files touched by the diff
+2. If any criterion requires exact round-trip of a value that the
+   underlying storage cannot represent (e.g., None in a NOT NULL column),
+   flag it as: severity: critical, problem: "criterion unsatisfiable"
+
+## Git diff
+
+{diff}
+{previous_findings}
+You may inspect the changed files and nearby code as needed.
+
+Check for:
+- requirement mismatches against the acceptance criteria above
+- broken or incomplete behavior
+- regressions
+- missing edge-case handling
+- unsafe assumptions
+- missing tests or inadequate test updates
+
+If the iteration is acceptable, output exactly:
+LGTM
+
+Otherwise, output a numbered list of findings.
+
+For each finding include:
+- severity: critical | major | minor
+- file: exact path(s) if applicable
+- problem: what is wrong, risky, or incomplete
+- evidence: what in the diff or code supports the finding
+- recommended fix: the smallest reasonable corrective action
+
+Only report findings that materially affect correctness, completeness, or reliability.
+{test_commands_guidance}
+{test_results}"""
+
 
 @dataclass
 class ToolConfig:
@@ -218,6 +337,18 @@ class PrdReviewConfig:
     fixer: str = "claude"
     fixer_prompt: str = _PRD_FIXER_PROMPT
     max_cycles: int = 3
+    enabled: bool = True
+
+
+@dataclass
+class PrdJsonReviewConfig:
+    """Review config for prd.json validation after conversion."""
+
+    reviewer: str = "codex"
+    reviewer_prompt: str = _PRD_JSON_REVIEW_PROMPT
+    fixer: str = "claude"
+    fixer_prompt: str = _PRD_JSON_FIXER_PROMPT
+    max_cycles: int = 2
     enabled: bool = True
 
 
@@ -279,6 +410,7 @@ class OrchestratedConfig:
     reviewer_timeout: int = 300  # seconds (5 min default)
     fixer_timeout: int = 600  # seconds (10 min default)
     review_prompt: str = _ORCHESTRATED_REVIEW_PROMPT
+    first_review_prompt: str = _ORCHESTRATED_REVIEW_FIRST_PROMPT
     fix_prompt: str = _ORCHESTRATED_FIX_PROMPT
     prompt_template: str | None = None
     story_filter: list[str] = field(default_factory=lambda: list[str]())
@@ -303,6 +435,7 @@ class Config:
 
     # Review stages
     prd_review: PrdReviewConfig = field(default_factory=PrdReviewConfig)
+    prd_json_review: PrdJsonReviewConfig = field(default_factory=PrdJsonReviewConfig)
     post_review: PostReviewConfig = field(default_factory=PostReviewConfig)
 
     # Ralph
@@ -549,6 +682,8 @@ def _build_config(data: dict[str, Any]) -> Config:
 
     if "prd_review" in data:
         cfg.prd_review = _parse_review(data["prd_review"], cfg.prd_review)
+    if "prd_json_review" in data:
+        cfg.prd_json_review = _parse_review(data["prd_json_review"], cfg.prd_json_review)
     if "post_review" in data:
         cfg.post_review = _parse_review(data["post_review"], cfg.post_review)
 
@@ -593,6 +728,7 @@ def _build_config(data: dict[str, Any]) -> Config:
             reviewer_timeout=int(o.get("reviewer_timeout", defaults.reviewer_timeout)),
             fixer_timeout=int(o.get("fixer_timeout", defaults.fixer_timeout)),
             review_prompt=o.get("review_prompt", defaults.review_prompt),
+            first_review_prompt=o.get("first_review_prompt", defaults.first_review_prompt),
             fix_prompt=o.get("fix_prompt", defaults.fix_prompt),
             prompt_template=o.get("prompt_template", defaults.prompt_template),
             story_filter=o.get("story_filter", defaults.story_filter),

--- a/ralph_pp/orchestrator.py
+++ b/ralph_pp/orchestrator.py
@@ -20,6 +20,7 @@ from .steps.prd import (
     convert_prd_to_json,
     feature_to_slug,
     generate_prd,
+    review_prd_json_loop,
     review_prd_loop,
 )
 from .steps.sandbox import RunSummary, run_sandbox, validate_sandbox_prerequisites
@@ -181,7 +182,8 @@ class Orchestrator:
         dest.parent.mkdir(exist_ok=True)
         shutil.copy2(prd_file, dest)
         console.print(f"[green]✓ PRD copied:[/green] {prd_file} → {dest}")
-        convert_prd_to_json(dest, self.worktree_path, self.config)
+        prd_json = convert_prd_to_json(dest, self.worktree_path, self.config)
+        review_prd_json_loop(dest, prd_json, self.worktree_path, self.config)
 
     def _step_prd(self, skip_review: bool, *, manual_prd: bool = False) -> None:
         assert self.worktree_path is not None
@@ -192,7 +194,8 @@ class Orchestrator:
         run_hooks("post_prd_generate", self.config.hooks, self.worktree_path)
         if not skip_review:
             review_prd_loop(prd_file, self.worktree_path, self.config)
-        convert_prd_to_json(prd_file, self.worktree_path, self.config)
+        prd_json = convert_prd_to_json(prd_file, self.worktree_path, self.config)
+        review_prd_json_loop(prd_file, prd_json, self.worktree_path, self.config)
 
     def _step_sandbox(self) -> None:
         assert self.worktree_path is not None

--- a/ralph_pp/steps/prd.py
+++ b/ralph_pp/steps/prd.py
@@ -1,4 +1,4 @@
-"""PRD generation, review loop, and prd.json conversion."""
+"""PRD generation, review loop, prd.json conversion, and prd.json review."""
 
 from __future__ import annotations
 
@@ -164,6 +164,7 @@ def review_prd_loop(prd_file: Path, worktree_path: Path, config: Config) -> None
                 review_cfg.reviewer_prompt,
                 prd_file=str(prd_file),
                 previous_findings=context,
+                repo_path=str(worktree_path),
             )
             result = reviewer.run(prompt=review_prompt, cwd=worktree_path)
             if not result.success:
@@ -270,3 +271,63 @@ def convert_prd_to_json(prd_file: Path, worktree_path: Path, config: Config) -> 
         raise RuntimeError(f"prd.json is not valid JSON: {e}") from e
     console.print(f"[green]✓ prd.json generated:[/green] {prd_json}")
     return prd_json
+
+
+def review_prd_json_loop(
+    prd_file: Path,
+    prd_json: Path,
+    worktree_path: Path,
+    config: Config,
+) -> None:
+    """Review generated prd.json against the original PRD and codebase.
+
+    Catches acceptance criteria that were sharpened, invented, or made
+    infeasible during the PRD-to-JSON conversion step.
+    """
+    review_cfg = config.prd_json_review
+    if not review_cfg.enabled:
+        console.print("[dim]prd.json review disabled — skipping[/dim]")
+        return
+
+    console.print("[bold cyan]\n── Step: prd.json Review ──[/bold cyan]")
+    reviewer = make_tool(review_cfg.reviewer, config)
+    fixer = make_tool(review_cfg.fixer, config)
+
+    for cycle in range(1, review_cfg.max_cycles + 1):
+        console.print(f"[bold]prd.json review cycle {cycle}/{review_cfg.max_cycles}[/bold]")
+
+        review_prompt = render_prompt(
+            review_cfg.reviewer_prompt,
+            prd_file=str(prd_file),
+            prd_json_file=str(prd_json),
+            repo_path=str(worktree_path),
+        )
+        result = reviewer.run(prompt=review_prompt, cwd=worktree_path)
+        if not result.success:
+            raise RuntimeError(
+                f"prd.json reviewer failed (exit {result.exit_code}): "
+                f"{(result.output or result.stderr)[:200]}"
+            )
+
+        if result.is_lgtm:
+            console.print("[green]✓ prd.json review passed (LGTM)[/green]")
+            return
+
+        console.print("[yellow]Issues found in prd.json — running fix pass...[/yellow]")
+        fix_prompt = render_prompt(
+            review_cfg.fixer_prompt,
+            prd_json_file=str(prd_json),
+            prd_file=str(prd_file),
+            findings=result.output,
+        )
+        fix_result = fixer.run(prompt=fix_prompt, cwd=worktree_path)
+        if not fix_result.success:
+            raise RuntimeError(
+                f"prd.json fixer failed (exit {fix_result.exit_code}): "
+                f"{(fix_result.output or fix_result.stderr)[:200]}"
+            )
+
+    console.print(
+        f"[yellow]⚠ prd.json review: max cycles ({review_cfg.max_cycles}) "
+        f"reached without LGTM — continuing[/yellow]"
+    )

--- a/ralph_pp/steps/sandbox.py
+++ b/ralph_pp/steps/sandbox.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import click
 from rich.console import Console
 
 from ..config import TEST_COMMANDS_GUIDANCE, Config, OrchestratedConfig
@@ -446,6 +447,7 @@ def _review_iteration(
     fixer_diff: str = "",
     stories_under_review: str = "",
     test_results: str = "",
+    first_review: bool = False,
 ) -> ReviewResult:
     """Run reviewer on the iteration diff."""
     orch = config.orchestrated
@@ -485,8 +487,12 @@ def _review_iteration(
     else:
         context = ""
 
+    # Use the feasibility-aware prompt for the first review of each iteration
+    prompt_template = (
+        orch.first_review_prompt if first_review and not previous_findings else orch.review_prompt
+    )
     review_prompt = render_prompt(
-        orch.review_prompt,
+        prompt_template,
         diff=diff,
         stories_under_review=stories_under_review,
         previous_findings=context,
@@ -824,6 +830,7 @@ def _run_orchestrated(
                 previous_findings=last_findings,
                 stories_under_review=stories_text,
                 test_results=test_results_text,
+                first_review=True,
             )
             last_findings = review.findings
 
@@ -852,6 +859,8 @@ def _run_orchestrated(
                     return False
             else:
                 # PATH B: Invoke fixer to fix in-place
+                prev_fix_findings: str = ""
+                escalation_count = 0
                 for fix_cycle in range(1, orch.max_iteration_retries + 1):
                     total_retries += 1
                     counters["retries"] = total_retries
@@ -905,6 +914,36 @@ def _run_orchestrated(
                     if review.passed:
                         iteration_passed = True
                         break
+
+                    # Detect escalating findings — new issues each cycle
+                    # suggests a spec-level problem, not an implementation bug
+                    if prev_fix_findings and review.findings != prev_fix_findings:
+                        escalation_count += 1
+                    prev_fix_findings = review.findings
+
+                    if escalation_count >= 2:
+                        console.print(
+                            f"\n  [bold yellow]⚠ Fix cycles for iteration {iteration} "
+                            f"show escalating findings (new issues each cycle)."
+                            f"[/bold yellow]\n"
+                            f"  [yellow]This suggests a spec-level issue, not an "
+                            f"implementation bug.[/yellow]"
+                        )
+                        action = click.prompt(
+                            "  Choose [skip/continue/quit]",
+                            type=click.Choice(["skip", "continue", "quit"]),
+                            default="skip",
+                        )
+                        if action == "quit":
+                            console.print("  [red]Aborting by user request[/red]")
+                            return False
+                        if action == "skip":
+                            console.print(
+                                f"  [yellow]Skipping iteration {iteration} — "
+                                f"continuing to next story[/yellow]"
+                            )
+                            break
+                        # action == "continue" → keep going through remaining cycles
 
                 if not iteration_passed:
                     console.print(

--- a/tests/test_prd.py
+++ b/tests/test_prd.py
@@ -1,10 +1,15 @@
-"""Tests for PRD generation and conversion artifact validation."""
+"""Tests for PRD generation, conversion, and prd.json review."""
 
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from ralph_pp.steps.prd import convert_prd_to_json, feature_to_slug, generate_prd
+from ralph_pp.steps.prd import (
+    convert_prd_to_json,
+    feature_to_slug,
+    generate_prd,
+    review_prd_json_loop,
+)
 from ralph_pp.tools.base import ToolResult
 
 
@@ -19,6 +24,12 @@ def _make_config():
                 args=["{prompt}"],
                 interactive=True,
                 allowed_tools=["Read", "Write", "Edit", "Glob", "Grep", "Bash(git:*)"],
+            ),
+            "codex": ToolConfig(command="codex", args=["{prompt}"]),
+            "claude": ToolConfig(
+                command="claude",
+                args=["--print"],
+                stdin="{prompt}",
             ),
         }
     )
@@ -152,3 +163,126 @@ class TestConvertPrdToJson:
 
             with pytest.raises(RuntimeError, match="not valid JSON"):
                 convert_prd_to_json(prd_file, tmp_path, config)
+
+
+class TestReviewPrdJsonLoop:
+    def test_lgtm_on_first_cycle(self, tmp_path):
+        """LGTM from reviewer on first cycle returns immediately."""
+        config = _make_config()
+        prd_file = tmp_path / "tasks" / "prd.md"
+        prd_file.parent.mkdir(parents=True)
+        prd_file.write_text("# PRD")
+        prd_json = tmp_path / "scripts" / "ralph" / "prd.json"
+        prd_json.parent.mkdir(parents=True)
+        prd_json.write_text('{"userStories": []}')
+
+        lgtm_result = ToolResult(output="LGTM", exit_code=0, success=True)
+
+        with patch("ralph_pp.steps.prd.make_tool") as mock_make:
+            mock_reviewer = MagicMock()
+            mock_reviewer.run.return_value = lgtm_result
+            mock_fixer = MagicMock()
+            mock_make.side_effect = [mock_reviewer, mock_fixer]
+
+            review_prd_json_loop(prd_file, prd_json, tmp_path, config)
+
+            assert mock_reviewer.run.call_count == 1
+            mock_fixer.run.assert_not_called()
+
+    def test_issues_trigger_fixer_then_re_review(self, tmp_path):
+        """Non-LGTM triggers fixer, then re-reviews."""
+        config = _make_config()
+        prd_file = tmp_path / "tasks" / "prd.md"
+        prd_file.parent.mkdir(parents=True)
+        prd_file.write_text("# PRD")
+        prd_json = tmp_path / "scripts" / "ralph" / "prd.json"
+        prd_json.parent.mkdir(parents=True)
+        prd_json.write_text('{"userStories": []}')
+
+        issue_result = ToolResult(
+            output="1. severity: major\n   problem: criterion infeasible",
+            exit_code=0,
+            success=True,
+        )
+        lgtm_result = ToolResult(output="LGTM", exit_code=0, success=True)
+        fix_result = ToolResult(output="Fixed", exit_code=0, success=True)
+
+        with patch("ralph_pp.steps.prd.make_tool") as mock_make:
+            mock_reviewer = MagicMock()
+            mock_reviewer.run.side_effect = [issue_result, lgtm_result]
+            mock_fixer = MagicMock()
+            mock_fixer.run.return_value = fix_result
+            mock_make.side_effect = [mock_reviewer, mock_fixer]
+
+            review_prd_json_loop(prd_file, prd_json, tmp_path, config)
+
+            assert mock_reviewer.run.call_count == 2
+            assert mock_fixer.run.call_count == 1
+
+    def test_max_cycles_exhaustion_continues(self, tmp_path):
+        """Max cycles reached without LGTM warns but continues."""
+        config = _make_config()
+        prd_file = tmp_path / "tasks" / "prd.md"
+        prd_file.parent.mkdir(parents=True)
+        prd_file.write_text("# PRD")
+        prd_json = tmp_path / "scripts" / "ralph" / "prd.json"
+        prd_json.parent.mkdir(parents=True)
+        prd_json.write_text('{"userStories": []}')
+
+        issue_result = ToolResult(
+            output="1. severity: major\n   problem: still broken",
+            exit_code=0,
+            success=True,
+        )
+        fix_result = ToolResult(output="Attempted fix", exit_code=0, success=True)
+
+        with patch("ralph_pp.steps.prd.make_tool") as mock_make:
+            mock_reviewer = MagicMock()
+            mock_reviewer.run.return_value = issue_result
+            mock_fixer = MagicMock()
+            mock_fixer.run.return_value = fix_result
+            mock_make.side_effect = [mock_reviewer, mock_fixer]
+
+            # Should not raise — just warns and continues
+            review_prd_json_loop(prd_file, prd_json, tmp_path, config)
+
+            # Default max_cycles is 2
+            assert mock_reviewer.run.call_count == 2
+            assert mock_fixer.run.call_count == 2
+
+    def test_disabled_skips_review(self, tmp_path):
+        """Disabled config skips the review entirely."""
+        from ralph_pp.config import PrdJsonReviewConfig
+
+        config = _make_config()
+        config.prd_json_review = PrdJsonReviewConfig(enabled=False)
+
+        prd_file = tmp_path / "tasks" / "prd.md"
+        prd_json = tmp_path / "scripts" / "ralph" / "prd.json"
+
+        with patch("ralph_pp.steps.prd.make_tool") as mock_make:
+            review_prd_json_loop(prd_file, prd_json, tmp_path, config)
+            mock_make.assert_not_called()
+
+    def test_reviewer_prompt_includes_repo_path(self, tmp_path):
+        """Reviewer prompt should include the codebase path."""
+        config = _make_config()
+        prd_file = tmp_path / "tasks" / "prd.md"
+        prd_file.parent.mkdir(parents=True)
+        prd_file.write_text("# PRD")
+        prd_json = tmp_path / "scripts" / "ralph" / "prd.json"
+        prd_json.parent.mkdir(parents=True)
+        prd_json.write_text('{"userStories": []}')
+
+        lgtm_result = ToolResult(output="LGTM", exit_code=0, success=True)
+
+        with patch("ralph_pp.steps.prd.make_tool") as mock_make:
+            mock_reviewer = MagicMock()
+            mock_reviewer.run.return_value = lgtm_result
+            mock_fixer = MagicMock()
+            mock_make.side_effect = [mock_reviewer, mock_fixer]
+
+            review_prd_json_loop(prd_file, prd_json, tmp_path, config)
+
+            call_kwargs = mock_reviewer.run.call_args[1]
+            assert str(tmp_path) in call_kwargs["prompt"]


### PR DESCRIPTION
## Summary

Adds four improvements to catch contradictory PRDs before they waste iteration cycles, motivated by the case45-orch-fixinplace-with-prd post-mortem.

- **PRD reviewer reads the codebase** — cross-references canonical contracts against actual types and schemas
- **prd.json review step after conversion** — catches criteria sharpened or invented during PRD-to-JSON conversion
- **Escalating fix failure detection** — prompts user when fix cycles show new issues each round (spec-level problem signal)
- **First-review feasibility pre-check** — iteration reviewer checks structural satisfiability on first review of each story

## Background

In case45, a PRD defined `last_access: datetime | None` but the SQLite schema had `NOT NULL`, the PRD said "no schema migration", and acceptance criteria demanded "all fields match exactly". These four statements are mutually unsatisfiable. The existing PRD reviewer only reads the PRD document (never the codebase), so it couldn't catch the contradiction. The fix cycle then thrashed for 3 rounds before exhausting, causing early exit at 4/13 stories.

See `/tmp/report2.md` for the full post-mortem analysis.

## Changes

| File | What |
|------|------|
| `ralph_pp/config.py` | Updated `_PRD_REVIEWER_PROMPT` with codebase feasibility check; added `_PRD_JSON_REVIEW_PROMPT`, `_PRD_JSON_FIXER_PROMPT`, `_ORCHESTRATED_REVIEW_FIRST_PROMPT`; added `PrdJsonReviewConfig` dataclass; added `first_review_prompt` to `OrchestratedConfig` |
| `ralph_pp/steps/prd.py` | Added `review_prd_json_loop()` function |
| `ralph_pp/orchestrator.py` | Wired `review_prd_json_loop` into `_step_prd()` and `_step_prd_from_file()` |
| `ralph_pp/steps/sandbox.py` | Added escalating-findings detection in fix cycle loop; added `first_review` flag to `_review_iteration()` |
| `tests/test_prd.py` | Added 5 tests for `review_prd_json_loop` |

## Test plan

- [x] `make check` passes (258 tests, 0 lint errors, 0 type errors)
- [ ] Manual: run with a PRD that has a known infeasible criterion — verify PRD reviewer catches it
- [ ] Manual: run orchestrated mode where fix cycles escalate — verify breakout prompt appears