### PR TITLE
fix: reviewer prompt improvements (#102, #93, #115)

### DIFF
--- a/ralph_pp/config.py
+++ b/ralph_pp/config.py
@@ -212,7 +212,7 @@ Do NOT evaluate against stories that are not listed here.
 ## Stories under review
 
 {stories_under_review}
-
+{prior_findings_summary}
 ## Git diff
 
 {diff}
@@ -221,6 +221,10 @@ You may inspect the changed files and nearby code as needed.
 
 Check for:
 - requirement mismatches against the acceptance criteria above
+- contract / invariant enforcement (not just "looks correct" — verify
+  the code actually enforces the constraints implied by the criteria;
+  e.g., if a criterion says "X must be UTC", the code must validate
+  this on input, not just when reading back)
 - broken or incomplete behavior
 - regressions
 - missing edge-case handling
@@ -238,6 +242,18 @@ For each finding include:
 - problem: what is wrong, risky, or incomplete
 - evidence: what in the diff or code supports the finding
 - recommended fix: the smallest reasonable corrective action
+
+## Severity discipline
+
+When a finding represents a design tradeoff (e.g., a pragmatic workaround
+with a theoretical edge case, rather than a concrete bug), rate it as
+**minor**. Reserve major / critical for findings where:
+- A test would fail on realistic input
+- A contract is violated in a way that affects callers
+- Data loss or corruption could occur in production use
+
+If you are unsure whether a finding is a bug or a design tradeoff,
+state both interpretations and rate based on the more charitable one.
 
 Only report findings that materially affect correctness, completeness, or reliability.
 {test_commands_guidance}
@@ -275,7 +291,7 @@ Do NOT evaluate against stories that are not listed here.
 ## Stories under review
 
 {stories_under_review}
-
+{prior_findings_summary}
 ## Feasibility pre-check
 
 Before reviewing the diff, check whether each acceptance criterion above
@@ -293,6 +309,10 @@ You may inspect the changed files and nearby code as needed.
 
 Check for:
 - requirement mismatches against the acceptance criteria above
+- contract / invariant enforcement (not just "looks correct" — verify
+  the code actually enforces the constraints implied by the criteria;
+  e.g., if a criterion says "X must be UTC", the code must validate
+  this on input, not just when reading back)
 - broken or incomplete behavior
 - regressions
 - missing edge-case handling
@@ -310,6 +330,18 @@ For each finding include:
 - problem: what is wrong, risky, or incomplete
 - evidence: what in the diff or code supports the finding
 - recommended fix: the smallest reasonable corrective action
+
+## Severity discipline
+
+When a finding represents a design tradeoff (e.g., a pragmatic workaround
+with a theoretical edge case, rather than a concrete bug), rate it as
+**minor**. Reserve major / critical for findings where:
+- A test would fail on realistic input
+- A contract is violated in a way that affects callers
+- Data loss or corruption could occur in production use
+
+If you are unsure whether a finding is a bug or a design tradeoff,
+state both interpretations and rate based on the more charitable one.
 
 Only report findings that materially affect correctness, completeness, or reliability.
 {test_commands_guidance}

--- a/ralph_pp/steps/sandbox.py
+++ b/ralph_pp/steps/sandbox.py
@@ -438,6 +438,55 @@ def truncate_diff(diff: str, max_chars: int) -> str:
     )
 
 
+def summarize_findings_for_history(
+    iteration: int,
+    findings: str,
+    *,
+    max_lines: int = 3,
+) -> list[str]:
+    """Extract one-line summaries from a reviewer's findings block (#102).
+
+    The history is shown to the next iteration's reviewer, so we want
+    short, scannable lines — not the full evidence/recommendation block.
+    Picks up to *max_lines* lines per iteration.
+    """
+    if not findings or "LGTM" in findings.split("\n", 1)[0]:
+        return []
+    summary: list[str] = []
+    for raw in findings.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        # Skip prose preambles; only capture lines that look like findings.
+        lower = line.lower()
+        if lower.startswith(("severity:", "problem:", "file:", "1.", "2.", "3.")):
+            # Trim long lines
+            if len(line) > 140:
+                line = line[:140] + "..."
+            summary.append(f"iter {iteration}: {line}")
+            if len(summary) >= max_lines:
+                break
+    return summary
+
+
+def _format_prior_findings_summary(prior: list[str] | None) -> str:
+    """Render prior-iteration findings as a context block for the reviewer (#102).
+
+    Returns an empty string when *prior* is empty so the placeholder
+    substitutes to nothing in the prompt.
+    """
+    if not prior:
+        return ""
+    lines = "\n".join(f"  - {entry}" for entry in prior)
+    return (
+        "\n## Prior iteration findings (this run)\n\n"
+        "Earlier iterations in this run produced these findings. Watch for\n"
+        "the same classes of bugs (e.g., contract enforcement, defensive copies,\n"
+        "edge cases) in this iteration's changes:\n\n"
+        f"{lines}\n"
+    )
+
+
 def _review_iteration(
     iteration: int,
     diff: str,
@@ -448,6 +497,7 @@ def _review_iteration(
     stories_under_review: str = "",
     test_results: str = "",
     first_review: bool = False,
+    prior_iteration_findings: list[str] | None = None,
 ) -> ReviewResult:
     """Run reviewer on the iteration diff."""
     orch = config.orchestrated
@@ -496,6 +546,7 @@ def _review_iteration(
         diff=diff,
         stories_under_review=stories_under_review,
         previous_findings=context,
+        prior_findings_summary=_format_prior_findings_summary(prior_iteration_findings),
         test_commands_guidance=_test_commands_guidance(orch),
         test_results=test_results,
     )
@@ -613,6 +664,11 @@ def _run_orchestrated(
     last_findings = ""
     consecutive_idle = 0
     total_retries = 0
+    # #102: rolling list of one-line summaries of findings raised in earlier
+    # iterations of this run, so the inline reviewer can spot recurring bug
+    # classes (defensive copies, contract enforcement, etc.) instead of
+    # treating each iteration in isolation.
+    prior_iteration_findings: list[str] = []
     prev_story_status = read_story_status(prd_json)
 
     # Apply story filter: treat non-filtered stories as already complete
@@ -831,6 +887,7 @@ def _run_orchestrated(
                 stories_under_review=stories_text,
                 test_results=test_results_text,
                 first_review=True,
+                prior_iteration_findings=prior_iteration_findings,
             )
             last_findings = review.findings
 
@@ -909,6 +966,7 @@ def _run_orchestrated(
                         fixer_diff=fix_diff,
                         stories_under_review=stories_text,
                         test_results=fix_test_results,
+                        prior_iteration_findings=prior_iteration_findings,
                     )
                     last_findings = review.findings
                     if review.passed:
@@ -951,6 +1009,17 @@ def _run_orchestrated(
                     )
                     return False
                 break  # In fix-in-place mode we don't retry the coder, only the fixer
+
+        # #102: roll up this iteration's findings (if any) into the
+        # cross-iteration history visible to the next iteration's reviewer.
+        if last_findings:
+            new_summary = summarize_findings_for_history(iteration, last_findings)
+            if new_summary:
+                prior_iteration_findings.extend(new_summary)
+                # Cap the rolling history so the prompt doesn't grow without
+                # bound across long runs.
+                if len(prior_iteration_findings) > 30:
+                    prior_iteration_findings[:] = prior_iteration_findings[-30:]
 
         # Update story status for next iteration
         prev_story_status = read_story_status(prd_json)

--- a/tests/test_sandbox_orchestrated.py
+++ b/tests/test_sandbox_orchestrated.py
@@ -2183,6 +2183,8 @@ class TestPriorIterationFindings:
 
     def test_orchestrator_accumulates_findings_across_iterations(self, tmp_path):
         """Iteration 2's reviewer should see iteration 1's findings."""
+
+
 # ── Issue #114: circuit-breaker for consecutive infra failures ─────────
 
 
@@ -2572,10 +2574,6 @@ class TestReviewerPromptContent:
 
         assert "{prior_findings_summary}" in _ORCHESTRATED_REVIEW_PROMPT
         assert "{prior_findings_summary}" in _ORCHESTRATED_REVIEW_FIRST_PROMPT
-        state = json.loads(prd.read_text())
-        by_id = {s["id"]: s["passes"] for s in state["userStories"]}
-        assert by_id["US-001"] is True
-        assert by_id["US-002"] is False
 
 
 # ── Issue #127: skip-and-advance on retry exhaustion ───────────────────

--- a/tests/test_sandbox_orchestrated.py
+++ b/tests/test_sandbox_orchestrated.py
@@ -2073,3 +2073,184 @@ class TestStoryScopedReview:
 
         assert captured_stories_arg is not None
         assert "did not mark any story" in captured_stories_arg
+
+
+# ── Issue #102: cumulative awareness across iterations ─────────────────
+
+
+class TestPriorIterationFindings:
+    def test_summarize_findings_for_history_picks_finding_lines(self):
+        from ralph_pp.steps.sandbox import summarize_findings_for_history
+
+        findings = (
+            "1. severity: major\n"
+            "file: ralph_pp/foo.py\n"
+            "problem: missing UTC validation\n"
+            "evidence: line 42 omits the timezone check\n"
+            "recommended fix: add a guard"
+        )
+        summary = summarize_findings_for_history(3, findings)
+        assert summary, "expected at least one summary line"
+        assert any("iter 3:" in line for line in summary)
+        assert any("missing UTC validation" in line for line in summary)
+
+    def test_summarize_findings_returns_empty_for_lgtm(self):
+        from ralph_pp.steps.sandbox import summarize_findings_for_history
+
+        assert summarize_findings_for_history(1, "LGTM") == []
+
+    def test_summarize_findings_caps_lines(self):
+        from ralph_pp.steps.sandbox import summarize_findings_for_history
+
+        findings = "\n".join(f"{i}. severity: minor\nproblem: thing {i}" for i in range(1, 11))
+        summary = summarize_findings_for_history(2, findings, max_lines=3)
+        assert len(summary) == 3
+
+    def test_format_prior_findings_summary_empty(self):
+        from ralph_pp.steps.sandbox import _format_prior_findings_summary
+
+        assert _format_prior_findings_summary(None) == ""
+        assert _format_prior_findings_summary([]) == ""
+
+    def test_format_prior_findings_summary_with_entries(self):
+        from ralph_pp.steps.sandbox import _format_prior_findings_summary
+
+        result = _format_prior_findings_summary(
+            [
+                "iter 1: severity: minor problem: shallow copy",
+                "iter 2: severity: major problem: missing UTC validation",
+            ]
+        )
+        assert "Prior iteration findings" in result
+        assert "shallow copy" in result
+        assert "missing UTC validation" in result
+
+    def test_review_iteration_passes_prior_findings_to_prompt(self, tmp_path):
+        """The reviewer should receive the prior_findings_summary block."""
+        from ralph_pp.steps.sandbox import _review_iteration
+
+        worktree = _setup_worktree(tmp_path)
+        config = _make_config(tmp_path)
+        captured_prompt = {}
+
+        def fake_run(prompt, cwd):
+            captured_prompt["text"] = prompt
+            return ToolResult(success=True, output="LGTM", exit_code=0)
+
+        with patch("ralph_pp.steps.sandbox.CliTool") as mock_tool_cls:
+            mock_tool = MagicMock()
+            mock_tool.run.side_effect = fake_run
+            mock_tool_cls.return_value = mock_tool
+            _review_iteration(
+                1,
+                "diff",
+                worktree,
+                config,
+                stories_under_review="some story",
+                prior_iteration_findings=[
+                    "iter 1: severity: major problem: defensive copy missing"
+                ],
+            )
+
+        assert "text" in captured_prompt
+        assert "Prior iteration findings" in captured_prompt["text"]
+        assert "defensive copy missing" in captured_prompt["text"]
+
+    def test_orchestrator_accumulates_findings_across_iterations(self, tmp_path):
+        """Iteration 2's reviewer should see iteration 1's findings."""
+        worktree = _setup_worktree(tmp_path)
+        prd = worktree / "scripts" / "ralph" / "prd.json"
+        prd.write_text(
+            json.dumps(
+                {
+                    "userStories": [
+                        {"id": "US-001", "title": "A", "passes": False, "priority": 1},
+                        {"id": "US-002", "title": "B", "passes": False, "priority": 2},
+                    ]
+                }
+            )
+        )
+        config = _make_config(
+            tmp_path, max_iterations=2, max_iteration_retries=0, backout_on_failure=True
+        )
+        captured_prior: list[list[str]] = []
+
+        def mock_subprocess_run(cmd, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd:
+                return _fake_subprocess_run(returncode=0, stdout="abc1234")
+            if isinstance(cmd, list) and "diff" in cmd:
+                return _fake_subprocess_run(returncode=0, stdout="some diff")
+            data = json.loads(prd.read_text())
+            for s in data["userStories"]:
+                if not s["passes"]:
+                    s["passes"] = True
+                    break
+            prd.write_text(json.dumps(data))
+            return _fake_subprocess_run(returncode=0, stdout="coder output")
+
+        def mock_review(*args, **kwargs):
+            captured_prior.append(list(kwargs.get("prior_iteration_findings") or []))
+            if len(captured_prior) == 1:
+                return ReviewResult(
+                    passed=True,
+                    findings=("1. severity: minor\nfile: foo.py\nproblem: shallow copy in to_dict"),
+                    max_severity="minor",
+                    minor_only=True,
+                )
+            return ReviewResult(passed=True, findings="LGTM", max_severity=None, minor_only=True)
+
+        with (
+            patch("ralph_pp.steps.sandbox.subprocess.run", side_effect=mock_subprocess_run),
+            patch("ralph_pp.steps.sandbox._review_iteration", side_effect=mock_review),
+            patch("ralph_pp.steps.sandbox.commit_if_dirty", return_value=False),
+            patch("ralph_pp.steps.sandbox.get_head_sha", side_effect=_incrementing_sha()),
+            patch(
+                "ralph_pp.steps.sandbox._session_runner_path",
+                return_value=tmp_path / "scripts" / "ralph-single-step.sh",
+            ),
+        ):
+            _run_orchestrated(worktree, config)
+
+        # First iteration: prior list is empty
+        assert captured_prior[0] == []
+        # Second iteration: should contain at least one entry from iteration 1
+        assert any("iter 1:" in line for line in captured_prior[1]), captured_prior
+
+
+# ── Issue #115 + #93: reviewer prompt content checks ───────────────────
+
+
+class TestReviewerPromptContent:
+    def test_review_prompt_contains_severity_discipline(self):
+        """The default review prompt should include severity-discipline guidance (#115)."""
+        from ralph_pp.config import _ORCHESTRATED_REVIEW_PROMPT
+
+        assert "Severity discipline" in _ORCHESTRATED_REVIEW_PROMPT
+        assert "design tradeoff" in _ORCHESTRATED_REVIEW_PROMPT
+        assert "more charitable" in _ORCHESTRATED_REVIEW_PROMPT
+
+    def test_first_review_prompt_contains_severity_discipline(self):
+        from ralph_pp.config import _ORCHESTRATED_REVIEW_FIRST_PROMPT
+
+        assert "Severity discipline" in _ORCHESTRATED_REVIEW_FIRST_PROMPT
+        assert "design tradeoff" in _ORCHESTRATED_REVIEW_FIRST_PROMPT
+
+    def test_review_prompts_emphasize_contract_enforcement(self):
+        """Both review prompts should ask for contract/invariant verification (#93)."""
+        from ralph_pp.config import (
+            _ORCHESTRATED_REVIEW_FIRST_PROMPT,
+            _ORCHESTRATED_REVIEW_PROMPT,
+        )
+
+        for prompt in (_ORCHESTRATED_REVIEW_PROMPT, _ORCHESTRATED_REVIEW_FIRST_PROMPT):
+            assert "contract" in prompt.lower()
+            assert "invariant" in prompt.lower()
+
+    def test_review_prompts_have_prior_findings_placeholder(self):
+        from ralph_pp.config import (
+            _ORCHESTRATED_REVIEW_FIRST_PROMPT,
+            _ORCHESTRATED_REVIEW_PROMPT,
+        )
+
+        assert "{prior_findings_summary}" in _ORCHESTRATED_REVIEW_PROMPT
+        assert "{prior_findings_summary}" in _ORCHESTRATED_REVIEW_FIRST_PROMPT


### PR DESCRIPTION
Three related improvements to the orchestrated-mode reviewer prompts to catch more bugs earlier and reduce review-loop non-determinism. Bundled because they all touch the same two prompts.

## #102 — Cumulative awareness across iterations

The inline reviewer now sees a rolling summary of findings from earlier iterations in the same run. This helps it spot recurring bug classes (\"iteration 1 caught a defensive-copy issue → check iteration 4 for the same pattern\") instead of treating each iteration in isolation.

**Mechanics:**
- \`summarize_findings_for_history()\` extracts up to 3 short summary lines per iteration from the reviewer's full findings block.
- \`_format_prior_findings_summary()\` renders the rolling list as a context block in the prompt.
- Both built-in review prompts gained a \`{prior_findings_summary}\` placeholder.
- \`_review_iteration()\` accepts \`prior_iteration_findings: list[str] | None\` and forwards it to the prompt.
- \`_run_orchestrated()\` maintains the rolling list (capped at 30 entries to bound prompt growth on long runs) and passes it to every review call.

## #93 — Contract enforcement focus

Both review prompts now explicitly ask the reviewer to verify contract / invariant enforcement, not just \"looks correct\". Example guidance baked in:

> contract / invariant enforcement (not just \"looks correct\" — verify the code actually enforces the constraints implied by the criteria; e.g., if a criterion says \"X must be UTC\", the code must validate this on input, not just when reading back)

## #115 — Severity discipline

Both review prompts now include a \"Severity discipline\" section that discriminates design tradeoffs (rate as **minor**) from bugs (rate as **major** / **critical**):

> When a finding represents a design tradeoff (e.g., a pragmatic workaround with a theoretical edge case, rather than a concrete bug), rate it as **minor**. Reserve major / critical for findings where:
> - A test would fail on realistic input
> - A contract is violated in a way that affects callers
> - Data loss or corruption could occur in production use
>
> If you are unsure whether a finding is a bug or a design tradeoff, state both interpretations and rate based on the more charitable one.

This won't eliminate severity non-determinism entirely, but it gives the reviewer a heuristic for the ambiguous cases that caused identical code to survive in one run and abort in another.

## Test plan

- [x] \`make check\` — **279 passed** (was 268; 11 new tests)
- [x] \`summarize_findings_for_history\` — extracts finding lines, returns [] for LGTM, caps at max_lines
- [x] \`_format_prior_findings_summary\` — empty returns \`\"\"\`, non-empty renders the context block
- [x] \`_review_iteration\` passes \`prior_findings_summary\` into the rendered prompt (verified via captured CliTool input)
- [x] **Integration**: in a 2-iteration run, iteration 2's reviewer sees iteration 1's findings in \`prior_iteration_findings\`
- [x] Static prompt content: severity-discipline language present (#115)
- [x] Static prompt content: contract / invariant verification language present (#93)
- [x] Static prompt content: \`{prior_findings_summary}\` placeholder present in both prompts

## Related

- #25 (parallel story execution) — independent
- #118, #115 (PRD review improvements) — related but separate scope

Closes #102
Closes #93
Closes #115