### PR TITLE
fix: per-iteration timing, failure context, no double-print on timeout (#103, #83, #77)

### DIFF
--- a/ralph_pp/steps/sandbox.py
+++ b/ralph_pp/steps/sandbox.py
@@ -12,7 +12,9 @@ import json
 import logging
 import os
 import subprocess
+import time
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -580,6 +582,64 @@ def _merge_env(extra: dict[str, str]) -> dict[str, str]:
     return env
 
 
+def _format_duration(seconds: float) -> str:
+    """Format a wall-clock duration in seconds as 'Xm YYs' (#103)."""
+    seconds = max(0.0, float(seconds))
+    minutes, secs = divmod(int(round(seconds)), 60)
+    if minutes >= 60:
+        hours, minutes = divmod(minutes, 60)
+        return f"{hours}h {minutes}m {secs}s"
+    return f"{minutes}m {secs:02d}s"
+
+
+def _write_iteration_progress_entry(
+    worktree_path: Path,
+    iteration: int,
+    iteration_passed: bool,
+    duration_seconds: float,
+    findings: str,
+) -> None:
+    """Append a per-iteration entry to ``scripts/ralph/progress.txt``.
+
+    Includes duration (#103) and a one-line failure reason for failed
+    iterations (#83).
+    """
+    progress_file = worktree_path / "scripts" / "ralph" / "progress.txt"
+    progress_file.parent.mkdir(parents=True, exist_ok=True)
+    status = "passed" if iteration_passed else "failed"
+    failure_summary = ""
+    if not iteration_passed and findings:
+        summary = _summarize_findings_for_progress(findings)
+        if summary:
+            failure_summary = f"Reason: {summary}\n"
+    with open(progress_file, "a") as f:
+        f.write(
+            f"\n## Iteration {iteration} — {status} "
+            f"(duration {_format_duration(duration_seconds)})\n"
+            f"{failure_summary}---\n"
+        )
+
+
+def _summarize_findings_for_progress(findings: str, max_chars: int = 240) -> str:
+    """Extract a one-line failure summary from reviewer findings (#83).
+
+    Picks the first finding's problem line if present, otherwise the first
+    non-empty line. Trimmed to *max_chars* with an ellipsis.
+    """
+    if not findings:
+        return ""
+    lines = [line.strip() for line in findings.splitlines() if line.strip()]
+    # Prefer a 'problem:' line if any
+    for line in lines:
+        if line.lower().startswith("problem:"):
+            text = line[len("problem:") :].strip()
+            return text[:max_chars] + ("..." if len(text) > max_chars else "")
+    if lines:
+        text = lines[0]
+        return text[:max_chars] + ("..." if len(text) > max_chars else "")
+    return ""
+
+
 def _save_counters(worktree_path: Path, iterations: int, retries: int) -> None:
     """Persist iteration/retry counters for RunSummary."""
     counters = worktree_path / "scripts" / "ralph" / ".run-counters"
@@ -640,9 +700,14 @@ def _run_orchestrated(
 
         counters["iterations"] = iteration
         completed = sum(1 for v in prev_story_status.values() if v)
+        # #103: per-iteration timing — record start wallclock and start
+        # monotonic so we can emit a duration at the end of the iteration.
+        iter_start_monotonic = time.monotonic()
+        iter_start_wall = datetime.now(UTC).astimezone()
         console.print(
             f"\n[bold]═══ Iteration {iteration}/{config.ralph.max_iterations} "
-            f"({completed}/{total_stories} stories done) ═══[/bold]"
+            f"({completed}/{total_stories} stories done) "
+            f"started {iter_start_wall.strftime('%H:%M:%S')} ═══[/bold]"
         )
 
         pre_sha = get_head_sha(worktree_path)
@@ -701,6 +766,7 @@ def _run_orchestrated(
                 ralph_args=["1"],
             )
             console.print(f"  [dim]Running coder ({orch.coder})...[/dim]")
+            coder_timed_out = False
             try:
                 result = subprocess.run(
                     cmd,
@@ -712,6 +778,7 @@ def _run_orchestrated(
             except subprocess.TimeoutExpired:
                 console.print(f"  [red]✗ Coder timed out after {orch.coder_timeout}s[/red]")
                 result = subprocess.CompletedProcess(cmd, returncode=1, stdout="", stderr="timeout")
+                coder_timed_out = True
 
             combined_output = (result.stdout or "") + (result.stderr or "")
             if combined_output:
@@ -719,7 +786,10 @@ def _run_orchestrated(
 
             # Check for infra/sandbox failure
             if result.returncode != 0:
-                console.print(f"  [red]✗ Coder process failed (exit {result.returncode})[/red]")
+                # #77: skip the generic failure message when we already
+                # printed a more specific timeout message just above.
+                if not coder_timed_out:
+                    console.print(f"  [red]✗ Coder process failed (exit {result.returncode})[/red]")
                 if orch.backout_on_failure and attempt < max_attempts:
                     _backout_to(worktree_path, pre_sha, restore_files=restore_files)
                     continue
@@ -856,6 +926,15 @@ def _run_orchestrated(
                     console.print(
                         f"  [red]✗ All retries exhausted for iteration {iteration} — aborting[/red]"
                     )
+                    # #83 + #103: write the failure entry before bailing so
+                    # the user has a record of what went wrong.
+                    _write_iteration_progress_entry(
+                        worktree_path,
+                        iteration,
+                        iteration_passed=False,
+                        duration_seconds=time.monotonic() - iter_start_monotonic,
+                        findings=last_findings,
+                    )
                     return False
             else:
                 # PATH B: Invoke fixer to fix in-place
@@ -872,9 +951,13 @@ def _run_orchestrated(
                         review.findings, worktree_path, config, stories_text
                     )
                     if fixer_result.returncode != 0:
-                        console.print(
-                            f"  [red]✗ Fixer process failed (exit {fixer_result.returncode})[/red]"
-                        )
+                        # #77: don't double-print when _run_fixer_in_sandbox
+                        # already announced the timeout above.
+                        if (fixer_result.stderr or "").strip() != "timeout":
+                            console.print(
+                                f"  [red]✗ Fixer process failed "
+                                f"(exit {fixer_result.returncode})[/red]"
+                            )
                         break
 
                     # Force-commit any uncommitted fixer changes
@@ -949,6 +1032,14 @@ def _run_orchestrated(
                     console.print(
                         f"  [red]✗ Fix cycles exhausted for iteration {iteration} — aborting[/red]"
                     )
+                    # #83 + #103: write the failure entry before bailing.
+                    _write_iteration_progress_entry(
+                        worktree_path,
+                        iteration,
+                        iteration_passed=False,
+                        duration_seconds=time.monotonic() - iter_start_monotonic,
+                        findings=last_findings,
+                    )
                     return False
                 break  # In fix-in-place mode we don't retry the coder, only the fixer
 
@@ -961,16 +1052,24 @@ def _run_orchestrated(
                     prev_story_status[sid] = True
 
         updated_completed = sum(1 for v in prev_story_status.values() if v)
-        console.print(f"  [dim]Progress: {updated_completed}/{total_stories} stories done[/dim]")
+        # #103: emit per-iteration duration so users can identify whether
+        # time is dominated by coder, reviewer, or test runs.
+        iter_duration = time.monotonic() - iter_start_monotonic
+        console.print(
+            f"  [dim]Progress: {updated_completed}/{total_stories} stories done "
+            f"(iteration took {_format_duration(iter_duration)})[/dim]"
+        )
 
         # Append to progress (skip idle iterations — the coder writes its own
         # detailed entries via the orchestrated prompt)
         if consecutive_idle == 0:
-            progress_file = worktree_path / "scripts" / "ralph" / "progress.txt"
-            progress_file.parent.mkdir(parents=True, exist_ok=True)
-            status = "passed" if iteration_passed else "failed"
-            with open(progress_file, "a") as f:
-                f.write(f"\n## Iteration {iteration} — {status}\n---\n")
+            _write_iteration_progress_entry(
+                worktree_path,
+                iteration,
+                iteration_passed=iteration_passed,
+                duration_seconds=iter_duration,
+                findings=last_findings,
+            )
 
         # Early termination: if all stories are complete after this iteration,
         # skip remaining iterations instead of waiting for the coder to emit

--- a/tests/test_sandbox_orchestrated.py
+++ b/tests/test_sandbox_orchestrated.py
@@ -2073,3 +2073,188 @@ class TestStoryScopedReview:
 
         assert captured_stories_arg is not None
         assert "did not mark any story" in captured_stories_arg
+
+
+# ── Issue #103: per-iteration timing ───────────────────────────────────
+
+
+class TestPerIterationTiming:
+    def test_format_duration(self):
+        from ralph_pp.steps.sandbox import _format_duration
+
+        assert _format_duration(0) == "0m 00s"
+        assert _format_duration(30) == "0m 30s"
+        assert _format_duration(75) == "1m 15s"
+        assert _format_duration(3725) == "1h 2m 5s"
+        assert _format_duration(-5) == "0m 00s"
+
+    def test_iteration_banner_includes_start_time(self, tmp_path, capsys):
+        worktree = _setup_worktree(tmp_path)
+        config = _make_config(tmp_path, max_iterations=1, max_iteration_retries=0)
+
+        def mock_subprocess_run(cmd, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd:
+                return _fake_subprocess_run(returncode=0, stdout="abc1234")
+            if isinstance(cmd, list) and "diff" in cmd:
+                return _fake_subprocess_run(returncode=0, stdout="some diff")
+            return _fake_subprocess_run(returncode=0, stdout="coder output")
+
+        def mock_review(*args, **kwargs):
+            return ReviewResult(passed=True, findings="LGTM", max_severity=None, minor_only=True)
+
+        with (
+            patch("ralph_pp.steps.sandbox.subprocess.run", side_effect=mock_subprocess_run),
+            patch("ralph_pp.steps.sandbox._review_iteration", side_effect=mock_review),
+            patch("ralph_pp.steps.sandbox.commit_if_dirty", return_value=False),
+            patch("ralph_pp.steps.sandbox.get_head_sha", side_effect=_incrementing_sha()),
+            patch(
+                "ralph_pp.steps.sandbox._session_runner_path",
+                return_value=tmp_path / "scripts" / "ralph-single-step.sh",
+            ),
+        ):
+            _run_orchestrated(worktree, config)
+
+        captured = capsys.readouterr()
+        assert "Iteration 1/1" in captured.out
+        assert "started" in captured.out
+        assert "iteration took" in captured.out
+
+    def test_progress_txt_includes_duration_and_failure_reason(self, tmp_path):
+        """#103 + #83: progress.txt records duration and failure reason."""
+        worktree = _setup_worktree(tmp_path)
+        config = _make_config(
+            tmp_path,
+            max_iterations=1,
+            max_iteration_retries=0,
+            backout_on_failure=False,
+        )
+
+        def mock_subprocess_run(cmd, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd:
+                return _fake_subprocess_run(returncode=0, stdout="abc1234")
+            if isinstance(cmd, list) and "diff" in cmd:
+                return _fake_subprocess_run(returncode=0, stdout="some diff")
+            return _fake_subprocess_run(returncode=0, stdout="coder output")
+
+        def mock_review(*args, **kwargs):
+            return ReviewResult(
+                passed=False,
+                findings="1. severity: major\nproblem: missing UTC validation on input",
+                max_severity="major",
+                minor_only=False,
+            )
+
+        def mock_fixer(*args, **kwargs):
+            return _fake_subprocess_run(returncode=0)
+
+        with (
+            patch("ralph_pp.steps.sandbox.subprocess.run", side_effect=mock_subprocess_run),
+            patch("ralph_pp.steps.sandbox._review_iteration", side_effect=mock_review),
+            patch("ralph_pp.steps.sandbox._run_fixer_in_sandbox", side_effect=mock_fixer),
+            patch("ralph_pp.steps.sandbox.commit_if_dirty", return_value=False),
+            patch("ralph_pp.steps.sandbox.get_head_sha", side_effect=_incrementing_sha()),
+            patch(
+                "ralph_pp.steps.sandbox._session_runner_path",
+                return_value=tmp_path / "scripts" / "ralph-single-step.sh",
+            ),
+        ):
+            _run_orchestrated(worktree, config)
+
+        progress = (worktree / "scripts" / "ralph" / "progress.txt").read_text()
+        assert "Iteration 1 — failed" in progress
+        assert "duration" in progress
+        # Failure context line included (#83)
+        assert "Reason:" in progress
+        assert "missing UTC validation on input" in progress
+
+    def test_summarize_findings_for_progress(self):
+        from ralph_pp.steps.sandbox import _summarize_findings_for_progress
+
+        assert _summarize_findings_for_progress("") == ""
+        # Picks the first 'problem:' line
+        assert (
+            _summarize_findings_for_progress("severity: major\nproblem: thing broken\nfile: x")
+            == "thing broken"
+        )
+        # Falls back to first line
+        assert _summarize_findings_for_progress("\n\nfirst line\nsecond line") == "first line"
+        # Truncates long output
+        long = "x" * 500
+        result = _summarize_findings_for_progress(long, max_chars=100)
+        assert len(result) <= 103
+        assert result.endswith("...")
+
+
+# ── Issue #77: no double-message on coder/fixer timeout ────────────────
+
+
+class TestNoDoubleMessageOnTimeout:
+    def test_coder_timeout_does_not_double_print(self, tmp_path, capsys):
+        worktree = _setup_worktree(tmp_path)
+        config = _make_config(tmp_path, max_iterations=1, max_iteration_retries=0)
+        config.orchestrated.coder_timeout = 1
+
+        def mock_subprocess_run(cmd, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd:
+                return _fake_subprocess_run(returncode=0, stdout="abc1234")
+            if isinstance(cmd, list) and "diff" in cmd:
+                return _fake_subprocess_run(returncode=0, stdout="some diff")
+            raise subprocess.TimeoutExpired(cmd, timeout=1)
+
+        with (
+            patch("ralph_pp.steps.sandbox.subprocess.run", side_effect=mock_subprocess_run),
+            patch("ralph_pp.steps.sandbox.commit_if_dirty", return_value=False),
+            patch("ralph_pp.steps.sandbox.get_head_sha", side_effect=_incrementing_sha()),
+            patch(
+                "ralph_pp.steps.sandbox._session_runner_path",
+                return_value=tmp_path / "scripts" / "ralph-single-step.sh",
+            ),
+        ):
+            _run_orchestrated(worktree, config)
+
+        captured = capsys.readouterr()
+        assert "Coder timed out after 1s" in captured.out
+        assert "Coder process failed" not in captured.out
+
+    def test_fixer_timeout_does_not_double_print(self, tmp_path, capsys):
+        worktree = _setup_worktree(tmp_path)
+        config = _make_config(
+            tmp_path,
+            max_iterations=1,
+            max_iteration_retries=1,
+            backout_on_failure=False,
+        )
+        config.orchestrated.fixer_timeout = 1
+
+        coder_calls = {"n": 0}
+
+        def mock_subprocess_run(cmd, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd:
+                return _fake_subprocess_run(returncode=0, stdout="abc1234")
+            if isinstance(cmd, list) and "diff" in cmd:
+                return _fake_subprocess_run(returncode=0, stdout="some diff")
+            coder_calls["n"] += 1
+            if coder_calls["n"] == 1:
+                return _fake_subprocess_run(returncode=0, stdout="coder output")
+            raise subprocess.TimeoutExpired(cmd, timeout=1)
+
+        def mock_review(*args, **kwargs):
+            return ReviewResult(
+                passed=False, findings="bad", max_severity="major", minor_only=False
+            )
+
+        with (
+            patch("ralph_pp.steps.sandbox.subprocess.run", side_effect=mock_subprocess_run),
+            patch("ralph_pp.steps.sandbox._review_iteration", side_effect=mock_review),
+            patch("ralph_pp.steps.sandbox.commit_if_dirty", return_value=False),
+            patch("ralph_pp.steps.sandbox.get_head_sha", side_effect=_incrementing_sha()),
+            patch(
+                "ralph_pp.steps.sandbox._session_runner_path",
+                return_value=tmp_path / "scripts" / "ralph-single-step.sh",
+            ),
+        ):
+            _run_orchestrated(worktree, config)
+
+        captured = capsys.readouterr()
+        assert "Fixer timed out after 1s" in captured.out
+        assert "Fixer process failed" not in captured.out


### PR DESCRIPTION
Three small logging/UX fixes bundled because they all touch the same orchestrator iteration loop in \`sandbox.py\`.

## #103 — per-iteration timing

- Capture monotonic clock at iteration start; print start time in the iteration banner.
- Emit duration in the per-iteration progress line.

\`\`\`
═══ Iteration 3/30 (5/14 stories done) started 14:22:08 ═══
  Running coder (claude)...
  ...
  Progress: 6/14 stories done (iteration took 4m 12s)
\`\`\`

New \`_format_duration()\` helper renders \`Xm YYs\` (or \`Xh Ym Zs\` for >= 1h).

## #83 — failure context in progress.txt

\`progress.txt\` entries previously read just \`## Iteration N — failed\`. Now they include duration **and** a one-line failure reason:

\`\`\`
## Iteration 3 — failed (duration 5m 12s)
Reason: missing UTC validation on input
---
\`\`\`

The new \`_write_iteration_progress_entry()\` helper consolidates the entry-write logic, and the abort paths (backout exhaustion + fix-cycles exhaustion) now also call it before \`return False\`, so failed iterations leave a record instead of vanishing silently.

## #77 — no double-print on coder/fixer timeout

The \`TimeoutExpired\` handler synthesised a \`CompletedProcess(returncode=1)\`, which then fell through to the generic \`returncode != 0\` check and printed both:
\`\`\`
✗ Coder timed out after 1800s
✗ Coder process failed (exit 1)
\`\`\`

Now the timeout handler sets a flag (coder) or stamps \`stderr='timeout'\` (fixer) and the generic failure message is suppressed when it's set.

## Test plan

- [x] \`make check\` — **274 passed** (was 268; 6 new tests)
- [x] \`_format_duration\` — zero, sub-minute, multi-minute, multi-hour, negative
- [x] \`_summarize_findings_for_progress\` — empty, problem-line picking, fallback, truncation
- [x] Iteration banner contains the start time and \"iteration took\" line
- [x] progress.txt failure entries on the abort path contain duration AND the Reason line with the actual reviewer finding text
- [x] Coder timeout: \"Coder timed out after Xs\" fires but \"Coder process failed\" does NOT
- [x] Fixer timeout: \"Fixer timed out after Xs\" fires but \"Fixer process failed\" does NOT

Closes #103
Closes #83
Closes #77