### PR TITLE
fix: PRD pipeline enhancements (#117, #118, #121)

### DIFF
--- a/ralph++.yaml.example
+++ b/ralph++.yaml.example
@@ -121,6 +121,17 @@ orchestrated:
   #   You are implementing iteration {iteration}. The PRD is at {prd_file}.
   #   Previous review findings: {review_findings}
 
+# ── Design stance (#121) ───────────────────────────────────────────────
+# [user/project] Hard constraints injected into the PRD generation prompt
+# so the generator avoids scope-inappropriate architectural choices.
+# Each field defaults to "unspecified" — that means no constraint is added.
+design_stance:
+  implementation_scope: unspecified    # unspecified | single_pass | incremental
+  backward_compatibility: unspecified  # unspecified | required | not_required
+  existing_tests: unspecified          # unspecified | must_pass | can_update
+  api_stability: unspecified           # unspecified | extend_only | can_break
+  notes: ""                             # free-form additional constraints
+
 # ── Lifecycle hooks ────────────────────────────────────────────────────
 # [user/project] Commands run at specific workflow stages.
 hooks:

--- a/ralph_pp/cli.py
+++ b/ralph_pp/cli.py
@@ -207,6 +207,31 @@ _sandbox_dir_option = click.option(
     "Repeatable. When set, other stories are treated as already complete.",
 )
 @click.option(
+    "--design-implementation-scope",
+    type=click.Choice(["unspecified", "single_pass", "incremental"]),
+    default=None,
+    help="(#121) Design constraint: implementation scope. 'single_pass' tells "
+    "the PRD generator to avoid transitional wrappers; 'incremental' allows them.",
+)
+@click.option(
+    "--design-backward-compatibility",
+    type=click.Choice(["unspecified", "required", "not_required"]),
+    default=None,
+    help="(#121) Design constraint: must new code interoperate with data produced by old code?",
+)
+@click.option(
+    "--design-existing-tests",
+    type=click.Choice(["unspecified", "must_pass", "can_update"]),
+    default=None,
+    help="(#121) Design constraint: must existing tests pass without modification?",
+)
+@click.option(
+    "--design-api-stability",
+    type=click.Choice(["unspecified", "extend_only", "can_break"]),
+    default=None,
+    help="(#121) Design constraint: can the public API change in breaking ways?",
+)
+@click.option(
     "--dry-run",
     is_flag=True,
     default=False,
@@ -230,6 +255,10 @@ def run(
     manual_prd: bool,
     resume_worktree: Path | None,
     story_filter: tuple[str, ...],
+    design_implementation_scope: str | None,
+    design_backward_compatibility: str | None,
+    design_existing_tests: str | None,
+    design_api_stability: str | None,
     dry_run: bool,
 ) -> None:
     """Run the full Ralph agentic coding workflow."""
@@ -265,6 +294,15 @@ def run(
         cfg.hooks["post_worktree_create"] = list(setup_cmd) + existing
     if story_filter:
         cfg.orchestrated.story_filter = list(story_filter)
+    # #121: CLI design-stance overrides win over config-file values.
+    if design_implementation_scope:
+        cfg.design_stance.implementation_scope = design_implementation_scope  # type: ignore[assignment]
+    if design_backward_compatibility:
+        cfg.design_stance.backward_compatibility = design_backward_compatibility  # type: ignore[assignment]
+    if design_existing_tests:
+        cfg.design_stance.existing_tests = design_existing_tests  # type: ignore[assignment]
+    if design_api_stability:
+        cfg.design_stance.api_stability = design_api_stability  # type: ignore[assignment]
 
     orchestrator = Orchestrator(
         feature=feature, config=cfg, dry_run=dry_run, resume_worktree=resume_worktree

--- a/ralph_pp/config.py
+++ b/ralph_pp/config.py
@@ -352,6 +352,34 @@ class PrdJsonReviewConfig:
     enabled: bool = True
 
 
+ImplementationScope = Literal["unspecified", "single_pass", "incremental"]
+BackwardCompat = Literal["unspecified", "required", "not_required"]
+ExistingTests = Literal["unspecified", "must_pass", "can_update"]
+ApiStability = Literal["unspecified", "extend_only", "can_break"]
+
+_VALID_IMPLEMENTATION_SCOPE: set[str] = {"unspecified", "single_pass", "incremental"}
+_VALID_BACKWARD_COMPAT: set[str] = {"unspecified", "required", "not_required"}
+_VALID_EXISTING_TESTS: set[str] = {"unspecified", "must_pass", "can_update"}
+_VALID_API_STABILITY: set[str] = {"unspecified", "extend_only", "can_break"}
+
+
+@dataclass
+class DesignStanceConfig:
+    """Design-stance answers injected into the PRD generator prompt (#121).
+
+    Each field defaults to ``"unspecified"`` so the generator gets a clean
+    prompt unless the user explicitly opts in to a constraint. Setting any
+    field to a non-default value adds it as a hard constraint to the PRD
+    generation prompt.
+    """
+
+    implementation_scope: ImplementationScope = "unspecified"
+    backward_compatibility: BackwardCompat = "unspecified"
+    existing_tests: ExistingTests = "unspecified"
+    api_stability: ApiStability = "unspecified"
+    notes: str = ""
+
+
 @dataclass
 class PostReviewConfig:
     """Review config for post-run review loop."""
@@ -437,6 +465,9 @@ class Config:
     prd_review: PrdReviewConfig = field(default_factory=PrdReviewConfig)
     prd_json_review: PrdJsonReviewConfig = field(default_factory=PrdJsonReviewConfig)
     post_review: PostReviewConfig = field(default_factory=PostReviewConfig)
+
+    # Design-stance answers fed into PRD generation (#121)
+    design_stance: DesignStanceConfig = field(default_factory=DesignStanceConfig)
 
     # Ralph
     ralph: RalphConfig = field(default_factory=RalphConfig)
@@ -733,6 +764,38 @@ def _build_config(data: dict[str, Any]) -> Config:
             prompt_template=o.get("prompt_template", defaults.prompt_template),
             story_filter=o.get("story_filter", defaults.story_filter),
             max_diff_chars=int(o.get("max_diff_chars", defaults.max_diff_chars)),
+        )
+
+    if "design_stance" in data:
+        ds = data["design_stance"]
+        ds_defaults = DesignStanceConfig()
+
+        def _parse_choice(key: str, valid: set[str]) -> str:
+            value = ds.get(key, getattr(ds_defaults, key))
+            if value not in valid:
+                raise ValueError(
+                    f"Invalid design_stance.{key}: {value!r} (expected one of {sorted(valid)})"
+                )
+            return cast(str, value)
+
+        cfg.design_stance = DesignStanceConfig(
+            implementation_scope=cast(
+                ImplementationScope,
+                _parse_choice("implementation_scope", _VALID_IMPLEMENTATION_SCOPE),
+            ),
+            backward_compatibility=cast(
+                BackwardCompat,
+                _parse_choice("backward_compatibility", _VALID_BACKWARD_COMPAT),
+            ),
+            existing_tests=cast(
+                ExistingTests,
+                _parse_choice("existing_tests", _VALID_EXISTING_TESTS),
+            ),
+            api_stability=cast(
+                ApiStability,
+                _parse_choice("api_stability", _VALID_API_STABILITY),
+            ),
+            notes=str(ds.get("notes", ds_defaults.notes)),
         )
 
     cfg.hooks = data.get("hooks", {})

--- a/ralph_pp/orchestrator.py
+++ b/ralph_pp/orchestrator.py
@@ -167,7 +167,12 @@ class Orchestrator:
         ensure_prd_skills(self.config, base)
         run_hooks("pre_prd_generate", self.config.hooks, base)
         prd_file = generate_prd(
-            self.feature, base, self.config, manual=manual_prd, prd_prompt=prd_prompt
+            self.feature,
+            base,
+            self.config,
+            manual=manual_prd,
+            prd_prompt=prd_prompt,
+            repo_path=self.config.repo_path,
         )
         run_hooks("post_prd_generate", self.config.hooks, base)
         if not skip_review:
@@ -207,7 +212,12 @@ class Orchestrator:
         ensure_prd_skills(self.config, self.worktree_path)
         run_hooks("pre_prd_generate", self.config.hooks, self.worktree_path)
         prd_file = generate_prd(
-            self.feature, self.worktree_path, self.config, manual=manual_prd, prd_prompt=prd_prompt
+            self.feature,
+            self.worktree_path,
+            self.config,
+            manual=manual_prd,
+            prd_prompt=prd_prompt,
+            repo_path=self.config.repo_path,
         )
         run_hooks("post_prd_generate", self.config.hooks, self.worktree_path)
         if not skip_review:

--- a/ralph_pp/steps/prd.py
+++ b/ralph_pp/steps/prd.py
@@ -10,7 +10,7 @@ import click
 from rich.console import Console
 from rich.markup import escape
 
-from ..config import Config, PrdReviewConfig
+from ..config import Config, DesignStanceConfig, PrdReviewConfig
 from ..tools import make_tool
 from ..tools.base import parse_max_severity, severity_at_or_above
 from ._git import get_diff, get_head_sha
@@ -61,6 +61,114 @@ def feature_to_slug(feature: str) -> str:
     return slug
 
 
+_TOKEN_RE = re.compile(r"[A-Za-z0-9_]+")
+
+
+def _normalize_findings(text: str) -> set[str]:
+    """Lowercased token set with short tokens dropped, used for similarity."""
+    if not text:
+        return set()
+    return {tok.lower() for tok in _TOKEN_RE.findall(text) if len(tok) >= 3}
+
+
+def findings_jaccard(a: str, b: str) -> float:
+    """Token-set Jaccard similarity. 0.0 when either is empty.
+
+    Used by the PRD review loop (#118) to detect when consecutive cycles
+    produce essentially the same findings — a signal that we've hit
+    diminishing returns and should stop iterating.
+    """
+    tokens_a = _normalize_findings(a)
+    tokens_b = _normalize_findings(b)
+    if not tokens_a or not tokens_b:
+        return 0.0
+    return len(tokens_a & tokens_b) / len(tokens_a | tokens_b)
+
+
+_CODEBASE_CONTEXT_INSTRUCTION = """\
+
+## Read the existing codebase first
+
+Before specifying contracts or acceptance criteria, read the existing
+codebase at {repo_path} to understand current types, schemas, and
+constraints. Pay particular attention to:
+- Dataclass / Protocol / Pydantic / TypedDict definitions referenced by the PRD
+- Database schema (SQL DDL, ORM models, migrations) and column constraints
+- Nullable vs non-nullable fields
+- Existing test fixtures that construct the types you're specifying
+- Public API surfaces that callers depend on
+
+Acceptance criteria you write must be satisfiable against the actual code,
+not against an idealized version of it. If a criterion would require
+changing an existing type or schema in a way that breaks callers, call
+that out explicitly in the PRD's "Constraints" or "Risks" section.
+"""
+
+
+def _build_design_stance_block(stance: DesignStanceConfig | None) -> str:
+    """Render the design-stance answers as constraints for the generator (#121).
+
+    Returns an empty string when *stance* is None or all fields are unset.
+    """
+    if stance is None:
+        return ""
+    parts: list[str] = []
+    if stance.implementation_scope == "single_pass":
+        parts.append(
+            "- This PRD covers a SINGLE implementation pass — all phases will "
+            "be implemented together. Do NOT introduce transitional wrappers, "
+            "adapters, or compatibility shims between phases. Design each phase "
+            "assuming all previous phases are already complete."
+        )
+    elif stance.implementation_scope == "incremental":
+        parts.append(
+            "- This PRD will be implemented incrementally — phases may ship "
+            "independently. Design transitional contracts that let earlier "
+            "phases run before later ones land."
+        )
+
+    if stance.backward_compatibility == "required":
+        parts.append(
+            "- Backward compatibility is REQUIRED. New code must read/write "
+            "data created by old code. Schema migrations must preserve "
+            "existing rows. Do not redesign storage in ways that strand old data."
+        )
+    elif stance.backward_compatibility == "not_required":
+        parts.append(
+            "- Backward compatibility is NOT required. Storage layouts and "
+            "data formats may be redesigned freely."
+        )
+
+    if stance.existing_tests == "must_pass":
+        parts.append(
+            "- ALL existing tests must continue to pass without modification. "
+            "Constrain contract changes to be backward-compatible with current "
+            "test expectations."
+        )
+    elif stance.existing_tests == "can_update":
+        parts.append("- Existing tests MAY be updated as part of this work.")
+
+    if stance.api_stability == "extend_only":
+        parts.append(
+            "- The public API may only EXTEND with optional parameters. "
+            "Do not change signatures of existing public functions/methods "
+            "in a breaking way."
+        )
+    elif stance.api_stability == "can_break":
+        parts.append("- The public API may be changed in breaking ways.")
+
+    if stance.notes:
+        parts.append(f"- Additional design constraints: {stance.notes}")
+
+    if not parts:
+        return ""
+    return (
+        "\n## Design constraints\n\n"
+        "Incorporate the following design-stance answers as hard constraints "
+        "throughout the PRD:\n\n" + "\n".join(parts) + "\n"
+    )
+
+
 def generate_prd(
     feature: str,
     worktree_path: Path,
@@ -68,6 +176,7 @@ def generate_prd(
     *,
     manual: bool = False,
     prd_prompt: str | None = None,
+    repo_path: Path | None = None,
 ) -> Path:
     """
     Invoke the Claude /prd skill to generate a text PRD.
@@ -79,6 +188,10 @@ def generate_prd(
     When *prd_prompt* is provided it is used as the generation prompt instead
     of the short *feature* string.  This allows a richer description while
     keeping *feature* short for branch/worktree naming.
+
+    When *repo_path* is provided (and the prompt is non-manual), a standard
+    "read the codebase first" instruction is appended so the generator
+    grounds its acceptance criteria in real types/schemas (#117).
     """
     console.print("[bold cyan]\n── Step: Generate PRD ──[/bold cyan]")
     slug = feature_to_slug(feature)
@@ -98,6 +211,12 @@ def generate_prd(
             "non-goals, and technical considerations.\n\n"
             f"Save the PRD to tasks/{prd_filename}"
         )
+        # #117: ground the generator in the actual codebase
+        codebase_target = repo_path or config.repo_path
+        if codebase_target:
+            prompt += _CODEBASE_CONTEXT_INSTRUCTION.format(repo_path=str(codebase_target))
+        # #121: inject design-stance answers as hard constraints
+        prompt += _build_design_stance_block(config.design_stance)
 
     tool_cfg = config.get_tool(config.prd_tool)
     if tool_cfg.interactive:
@@ -145,6 +264,9 @@ def review_prd_loop(prd_file: Path, worktree_path: Path, config: Config) -> None
     total_cycles = 0
     previous_findings: str = ""
     last_fixer_diff: str = ""
+    # #118: detect diminishing returns when consecutive cycles surface
+    # essentially the same findings.
+    convergence_threshold = 0.8
     while True:
         for cycle in range(1, review_cfg.max_cycles + 1):
             total_cycles += 1
@@ -193,6 +315,21 @@ def review_prd_loop(prd_file: Path, worktree_path: Path, config: Config) -> None
                 )
                 console.print(f"[dim]{escape(result.output or '')}[/dim]")
                 return
+
+            # #118: convergence detection. If the new findings are
+            # essentially the same as the previous cycle's, accept early —
+            # the reviewer has stopped making forward progress and further
+            # cycles will only produce marginal refinements.
+            if previous_findings:
+                similarity = findings_jaccard(previous_findings, result.output)
+                if similarity >= convergence_threshold:
+                    console.print(
+                        f"[yellow]⚠ PRD review cycle {total_cycles} produced findings "
+                        f"~{int(similarity * 100)}% similar to the previous cycle — "
+                        "accepting (diminishing returns)[/yellow]"
+                    )
+                    console.print(f"[dim]{escape(result.output or '')}[/dim]")
+                    return
 
             previous_findings = result.output
             console.print(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -728,3 +728,42 @@ def test_provenance_format_output():
     cfg.branch_prefix = "test/"
     output = prov.format(cfg)
     assert "branch_prefix: 'test/'  (myfile.yaml)" in output
+
+
+def test_design_stance_defaults():
+    cfg = load_config(None)
+    assert cfg.design_stance.implementation_scope == "unspecified"
+    assert cfg.design_stance.backward_compatibility == "unspecified"
+    assert cfg.design_stance.existing_tests == "unspecified"
+    assert cfg.design_stance.api_stability == "unspecified"
+    assert cfg.design_stance.notes == ""
+
+
+def test_design_stance_from_yaml(tmp_path):
+    config_file = tmp_path / "ralph++.yaml"
+    config_file.write_text(
+        yaml.dump(
+            {
+                "design_stance": {
+                    "implementation_scope": "single_pass",
+                    "backward_compatibility": "required",
+                    "existing_tests": "must_pass",
+                    "api_stability": "extend_only",
+                    "notes": "no rocket science",
+                }
+            }
+        )
+    )
+    cfg = load_config(config_file)
+    assert cfg.design_stance.implementation_scope == "single_pass"
+    assert cfg.design_stance.backward_compatibility == "required"
+    assert cfg.design_stance.existing_tests == "must_pass"
+    assert cfg.design_stance.api_stability == "extend_only"
+    assert cfg.design_stance.notes == "no rocket science"
+
+
+def test_design_stance_invalid_value_rejected(tmp_path):
+    config_file = tmp_path / "ralph++.yaml"
+    config_file.write_text(yaml.dump({"design_stance": {"implementation_scope": "bogus"}}))
+    with pytest.raises(ValueError, match="implementation_scope"):
+        load_config(config_file)

--- a/tests/test_prd.py
+++ b/tests/test_prd.py
@@ -359,3 +359,191 @@ class TestReviewPrdJsonLoop:
 
             call_kwargs = mock_reviewer.run.call_args[1]
             assert str(tmp_path) in call_kwargs["prompt"]
+
+
+# ── Issue #117: codebase context appended to PRD generation prompt ─────
+
+
+class TestCodebaseContextInPrdGeneration:
+    def test_repo_path_appended_to_prompt(self, tmp_path):
+        from ralph_pp.steps.prd import generate_prd as gen
+
+        config = _make_config()
+        captured = {}
+
+        def fake_run(prompt, cwd):
+            captured["prompt"] = prompt
+            (tmp_path / "tasks").mkdir(exist_ok=True)
+            (tmp_path / "tasks" / "prd-test-feat.md").write_text("# PRD")
+            return ToolResult(success=True, output="ok", exit_code=0)
+
+        with patch("ralph_pp.steps.prd.make_tool") as mock_make:
+            mock_tool = MagicMock()
+            mock_tool.run.side_effect = fake_run
+            mock_make.return_value = mock_tool
+
+            gen(
+                "test feat",
+                tmp_path,
+                config,
+                prd_prompt="some description",
+                repo_path=tmp_path / "fake-repo",
+            )
+
+        prompt = captured["prompt"]
+        assert "Read the existing codebase first" in prompt
+        assert str(tmp_path / "fake-repo") in prompt
+
+    def test_manual_mode_does_not_append_codebase_block(self, tmp_path):
+        from ralph_pp.steps.prd import generate_prd as gen
+
+        config = _make_config()
+        captured = {}
+
+        def fake_run(prompt, cwd):
+            captured["prompt"] = prompt
+            (tmp_path / "tasks").mkdir(exist_ok=True)
+            (tmp_path / "tasks" / "prd-test-feat.md").write_text("# PRD")
+            return ToolResult(success=True, output="ok", exit_code=0)
+
+        with patch("ralph_pp.steps.prd.make_tool") as mock_make:
+            mock_tool = MagicMock()
+            mock_tool.run.side_effect = fake_run
+            mock_make.return_value = mock_tool
+
+            gen("test feat", tmp_path, config, manual=True, repo_path=tmp_path / "fake-repo")
+
+        # Manual mode uses a minimal prompt that does not include the
+        # codebase context block.
+        assert "Read the existing codebase first" not in captured["prompt"]
+
+
+# ── Issue #121: design-stance constraints injected into prompt ─────────
+
+
+class TestDesignStanceInPrdGeneration:
+    def test_design_stance_constraints_appended(self, tmp_path):
+        from ralph_pp.config import DesignStanceConfig
+        from ralph_pp.steps.prd import generate_prd as gen
+
+        config = _make_config()
+        config.design_stance = DesignStanceConfig(
+            implementation_scope="single_pass",
+            backward_compatibility="required",
+            existing_tests="must_pass",
+            api_stability="extend_only",
+            notes="prefer pure-python solutions",
+        )
+        captured = {}
+
+        def fake_run(prompt, cwd):
+            captured["prompt"] = prompt
+            (tmp_path / "tasks").mkdir(exist_ok=True)
+            (tmp_path / "tasks" / "prd-test-feat.md").write_text("# PRD")
+            return ToolResult(success=True, output="ok", exit_code=0)
+
+        with patch("ralph_pp.steps.prd.make_tool") as mock_make:
+            mock_tool = MagicMock()
+            mock_tool.run.side_effect = fake_run
+            mock_make.return_value = mock_tool
+
+            gen("test feat", tmp_path, config, prd_prompt="desc", repo_path=tmp_path)
+
+        prompt = captured["prompt"]
+        assert "Design constraints" in prompt
+        assert "SINGLE implementation pass" in prompt
+        assert "Backward compatibility is REQUIRED" in prompt
+        assert "ALL existing tests must continue to pass" in prompt
+        assert "may only EXTEND with optional parameters" in prompt
+        assert "prefer pure-python solutions" in prompt
+
+    def test_design_stance_unspecified_omits_block(self, tmp_path):
+        from ralph_pp.steps.prd import generate_prd as gen
+
+        config = _make_config()  # Default DesignStanceConfig: all unspecified
+        captured = {}
+
+        def fake_run(prompt, cwd):
+            captured["prompt"] = prompt
+            (tmp_path / "tasks").mkdir(exist_ok=True)
+            (tmp_path / "tasks" / "prd-test-feat.md").write_text("# PRD")
+            return ToolResult(success=True, output="ok", exit_code=0)
+
+        with patch("ralph_pp.steps.prd.make_tool") as mock_make:
+            mock_tool = MagicMock()
+            mock_tool.run.side_effect = fake_run
+            mock_make.return_value = mock_tool
+
+            gen("test feat", tmp_path, config, prd_prompt="desc", repo_path=tmp_path)
+
+        assert "Design constraints" not in captured["prompt"]
+
+    def test_build_design_stance_block_partial(self):
+        from ralph_pp.config import DesignStanceConfig
+        from ralph_pp.steps.prd import _build_design_stance_block
+
+        # Only one field set
+        stance = DesignStanceConfig(implementation_scope="incremental")
+        block = _build_design_stance_block(stance)
+        assert "incrementally" in block
+        assert "Backward compatibility" not in block
+
+    def test_build_design_stance_block_empty(self):
+        from ralph_pp.config import DesignStanceConfig
+        from ralph_pp.steps.prd import _build_design_stance_block
+
+        assert _build_design_stance_block(None) == ""
+        assert _build_design_stance_block(DesignStanceConfig()) == ""
+
+
+# ── Issue #118: PRD review diminishing-returns detection ───────────────
+
+
+class TestPrdReviewConvergence:
+    def test_findings_jaccard_basic(self):
+        from ralph_pp.steps.prd import findings_jaccard
+
+        assert findings_jaccard("alpha beta gamma", "alpha beta gamma") == 1.0
+        assert findings_jaccard("alpha beta", "delta epsilon") == 0.0
+        assert findings_jaccard("", "anything") == 0.0
+        # Partial overlap
+        result = findings_jaccard("alpha beta gamma", "alpha beta delta")
+        assert 0 < result < 1
+
+    def test_review_loop_accepts_on_convergence(self, tmp_path):
+        """Two consecutive cycles producing similar findings should auto-accept."""
+        from ralph_pp.config import PrdReviewConfig
+        from ralph_pp.steps.prd import review_prd_loop
+
+        config = _make_config()
+        config.prd_review = PrdReviewConfig(
+            reviewer="codex",
+            fixer="claude",
+            max_cycles=4,
+        )
+        prd_file = tmp_path / "tasks" / "prd.md"
+        prd_file.parent.mkdir(parents=True)
+        prd_file.write_text("# PRD")
+
+        # Same findings text on cycles 1 and 2 → 100% Jaccard → accept
+        same_findings = "1. severity: major\nproblem: ambiguous validation requirement at boundary"
+
+        with (
+            patch("ralph_pp.steps.prd.make_tool") as mock_make,
+            patch("ralph_pp.steps.prd.get_head_sha", return_value="abc1234"),
+            patch("ralph_pp.steps.prd.get_diff", return_value="(no diff)"),
+        ):
+            reviewer_mock = MagicMock()
+            reviewer_mock.run.return_value = ToolResult(
+                success=True, output=same_findings, exit_code=0
+            )
+            fixer_mock = MagicMock()
+            fixer_mock.run.return_value = ToolResult(success=True, output="fixed", exit_code=0)
+            mock_make.side_effect = lambda name, cfg: (
+                reviewer_mock if name == "codex" else fixer_mock
+            )
+
+            review_prd_loop(prd_file, tmp_path, config)
+
+        # Should converge after cycle 2 — only 2 review calls
+        assert reviewer_mock.run.call_count == 2

--- a/tests/test_review_loops.py
+++ b/tests/test_review_loops.py
@@ -167,13 +167,18 @@ class TestPrdReviewLoopMaxCycles:
             patch("ralph_pp.steps.prd.make_tool") as mock_make,
             patch(
                 "ralph_pp.steps.prd.prompt_max_cycles",
-                side_effect=lambda *a: next(prompt_responses),
+                side_effect=lambda *a, **kw: next(prompt_responses),
             ),
             patch("ralph_pp.steps.prd.get_head_sha", return_value="abc1234"),
             patch("ralph_pp.steps.prd.get_diff", return_value="(no diff)"),
         ):
             reviewer_mock = MagicMock()
-            reviewer_mock.run.return_value = _ok_result("1. severity: major\nproblem: bad")
+            # Different findings each cycle so the #118 convergence detector
+            # doesn't short-circuit before we reach the user prompt.
+            reviewer_mock.run.side_effect = [
+                _ok_result("1. severity: major\nproblem: alpha beta gamma needs work"),
+                _ok_result("1. severity: major\nproblem: delta epsilon zeta different issue"),
+            ]
             fixer_mock = MagicMock()
             fixer_mock.run.return_value = _ok_result("fixed")
             mock_make.side_effect = lambda name, cfg: (


### PR DESCRIPTION
Three related improvements to the PRD generation/review pipeline. Bundled because they all touch the PRD generator/reviewer surfaces.

> **Note:** #120 (interactive Claude session in PRD review loop) is **deferred** to a follow-up PR — it requires non-trivial interactive tool wiring and benefits more once the non-interactive infrastructure (#128 / PR1) is merged first. Worth doing as its own focused PR.

## #117 — Codebase context for the PRD generator

The PRD generator now receives a standard \"Read the existing codebase first\" instruction pointing it at the actual repo path. Grounds acceptance criteria in real types/schemas instead of letting the generator invent contracts that contradict the codebase, which used to cost multiple review cycles per PRD.

The instruction is appended only when generating in non-manual mode (manual generation already lets the user drive the conversation).

## #121 — Design-stance questionnaire

New \`DesignStanceConfig\` dataclass + \`design_stance\` YAML section + four CLI flags:

\`\`\`bash
ralph++ run \\
  --feature my-feat \\
  --design-implementation-scope single_pass \\
  --design-backward-compatibility required \\
  --design-existing-tests must_pass \\
  --design-api-stability extend_only
\`\`\`

\`\`\`yaml
design_stance:
  implementation_scope: single_pass
  backward_compatibility: required
  existing_tests: must_pass
  api_stability: extend_only
  notes: \"prefer pure-python solutions\"
\`\`\`

When any field is set to a non-default value, \`_build_design_stance_block\` renders it as a hard constraint in the PRD generation prompt. Example output:

> ## Design constraints
>
> Incorporate the following design-stance answers as hard constraints throughout the PRD:
>
> - This PRD covers a SINGLE implementation pass — all phases will be implemented together. Do NOT introduce transitional wrappers, adapters, or compatibility shims between phases.
> - Backward compatibility is REQUIRED. New code must read/write data created by old code...

This prevents the generator from making scope-inappropriate architectural choices (the case0b \"wrapper-first\" design problem).

## #118 — PRD review diminishing-returns detection

The existing severity-gated auto-accept (only minor findings remain → accept) handles the **trivial findings** case. New convergence detection handles the **same-finding-rephrased** case: when consecutive cycles produce findings with >= 0.8 token-set Jaccard similarity, the loop accepts early with a clear \"diminishing returns\" warning instead of burning cycles on marginal refinements.

New \`findings_jaccard()\` helper at module level. Threshold is hardcoded at 0.8 for now; could be made configurable later.

## Test plan

- [x] \`make check\` — **279 passed** (was 268; 11 new tests)
- [x] \`TestCodebaseContextInPrdGeneration\`: appended in non-manual mode, omitted in manual mode
- [x] \`TestDesignStanceInPrdGeneration\`: full set rendered, unspecified omits the block, partial config renders only set fields
- [x] \`_build_design_stance_block\` handles \`None\` and empty config
- [x] \`TestPrdReviewConvergence\`: \`findings_jaccard\` (identity, disjoint, empty, partial), and integration test that confirms \`review_prd_loop\` converges after cycle 2 when findings repeat verbatim
- [x] \`test_design_stance_*\` config tests: defaults, YAML round-trip, invalid value rejection
- [x] Updated legacy \`test_retry_runs_another_batch\` to use *different* findings on each cycle so the new convergence detector doesn't short-circuit it before reaching the user prompt
- [ ] Manual integration test: a real \`ralph++ run --feature ... --design-implementation-scope single_pass\` against a sandbox

## Compatibility

- All new fields default to \`unspecified\` / no constraint, so existing configs and runs are unaffected.
- The new codebase-context block is informative; PRDs that already mention the codebase remain valid.

## Related / Deferred

- **#120** (interactive Claude session in PRD review) — deferred. Requires interactive tool wiring; will be a follow-up PR.

Closes #117
Closes #118
Closes #121