### PR TITLE
fix: interactive Claude session option in PRD review loop (#120)

### DIFF
--- a/ralph_pp/steps/prd.py
+++ b/ralph_pp/steps/prd.py
@@ -30,26 +30,90 @@ def prompt_max_cycles(
     phase: str,
     max_cycles: int,
     continue_label: str = "Continue — proceed without reviewer approval",
+    *,
+    allow_explore: bool = False,
 ) -> str:
     """Prompt the user for action when max review cycles are exhausted.
 
-    Returns one of: "quit", "retry", "continue".
+    Returns one of: "quit", "retry", "continue", or "explore" (when
+    *allow_explore* is True — see #120).
     """
     console.print(
         f"\n[yellow]⚠ {phase} review: max cycles ({max_cycles}) reached without LGTM[/yellow]"
     )
-    console.print(
+    options_text = (
         "[bold]Options:[/bold]\n"
         "  [cyan]1)[/cyan] Quit — abort the workflow\n"
         f"  [cyan]2)[/cyan] Retry — run another {max_cycles} review cycles\n"
         f"  [cyan]3)[/cyan] {continue_label}"
     )
+    valid_choices = ["1", "2", "3"]
+    if allow_explore:
+        options_text += (
+            "\n  [cyan]4)[/cyan] Explore — open an interactive session to "
+            "edit the PRD, then run another review cycle"
+        )
+        valid_choices.append("4")
+    console.print(options_text)
     choice = click.prompt(
         "Choose",
-        type=click.Choice(["1", "2", "3"]),
+        type=click.Choice(valid_choices),
         default="3",
     )
-    return {"1": "quit", "2": "retry", "3": "continue"}[choice]
+    mapping = {"1": "quit", "2": "retry", "3": "continue", "4": "explore"}
+    return mapping[choice]
+
+
+def _launch_interactive_explore(
+    phase: str,
+    target_file: Path,
+    findings: str,
+    config: Config,
+) -> None:
+    """Drop the user into an interactive Claude session to explore *target_file*.
+
+    Pre-loads the file path and last reviewer findings as context. Used by
+    the PRD review loops when the user picks the "Explore" option (#120).
+
+    Looks up an interactive tool by checking ``config.tools`` for any tool
+    with ``interactive=True``, preferring ``claude-interactive`` if present.
+    Raises ``RuntimeError`` when no interactive tool is configured.
+    """
+    interactive_tool_name: str | None = None
+    if "claude-interactive" in config.tools and config.tools["claude-interactive"].interactive:
+        interactive_tool_name = "claude-interactive"
+    else:
+        for name, tool_cfg in config.tools.items():
+            if tool_cfg.interactive:
+                interactive_tool_name = name
+                break
+
+    if interactive_tool_name is None:
+        raise RuntimeError(
+            "No interactive tool configured. Define a tool with `interactive: true` "
+            "in your ralph++.yaml (e.g. 'claude-interactive') to use the Explore option."
+        )
+
+    tool = make_tool(interactive_tool_name, config)
+    findings_block = ""
+    if findings:
+        findings_block = f"\n\nMost recent reviewer findings (verbatim):\n\n{findings.strip()}\n"
+    prompt = (
+        f"You are in an interactive review session for the {phase} at "
+        f"{target_file}. Read the file, discuss its design with the user, "
+        f"and edit it as needed. When you are done, type /exit to return "
+        f"to the ralph++ review loop, which will then run another review "
+        f"cycle to verify your changes.{findings_block}"
+    )
+    console.print(
+        f"\n[bold yellow]Opening interactive session ({interactive_tool_name}). "
+        "Type /exit when done.[/bold yellow]\n"
+    )
+    result = tool.run(prompt=prompt, cwd=target_file.parent)
+    if not result.success:
+        console.print(
+            f"[red]Interactive session ended with non-zero exit code ({result.exit_code})[/red]"
+        )
 
 
 def feature_to_slug(feature: str) -> str:
@@ -218,12 +282,30 @@ def review_prd_loop(prd_file: Path, worktree_path: Path, config: Config) -> None
                 )
                 last_fixer_diff = ""
 
-        action = prompt_max_cycles("PRD", review_cfg.max_cycles)
+        action = prompt_max_cycles("PRD", review_cfg.max_cycles, allow_explore=True)
         if action == "quit":
             raise MaxCyclesAbort
         if action == "continue":
             console.print("[yellow]Continuing without reviewer approval[/yellow]")
             return
+        if action == "explore":
+            # #120: drop into an interactive session, then run another batch
+            try:
+                _launch_interactive_explore(
+                    phase="PRD",
+                    target_file=prd_file,
+                    findings=previous_findings,
+                    config=config,
+                )
+            except RuntimeError as e:
+                console.print(f"[red]{e}[/red]")
+                console.print("[yellow]Falling back to retry[/yellow]")
+            console.print(f"[cyan]Resuming review loop ({review_cfg.max_cycles} cycles)...[/cyan]")
+            # Reset the per-batch context so the reviewer evaluates the
+            # post-explore PRD on its own merits.
+            previous_findings = ""
+            last_fixer_diff = ""
+            continue
         # action == "retry" → loop again
         console.print(f"[cyan]Retrying another {review_cfg.max_cycles} review cycles...[/cyan]")
 
@@ -367,10 +449,23 @@ def review_prd_json_loop(
                     f"{(fix_result.output or fix_result.stderr)[:200]}"
                 )
 
-        action = prompt_max_cycles("prd.json", review_cfg.max_cycles)
+        action = prompt_max_cycles("prd.json", review_cfg.max_cycles, allow_explore=True)
         if action == "quit":
             raise MaxCyclesAbort
         if action == "continue":
             console.print("[yellow]Continuing without prd.json reviewer approval[/yellow]")
             return
+        if action == "explore":
+            try:
+                _launch_interactive_explore(
+                    phase="prd.json",
+                    target_file=prd_json,
+                    findings="",
+                    config=config,
+                )
+            except RuntimeError as e:
+                console.print(f"[red]{e}[/red]")
+                console.print("[yellow]Falling back to retry[/yellow]")
+            console.print(f"[cyan]Resuming review loop ({review_cfg.max_cycles} cycles)...[/cyan]")
+            continue
         console.print(f"[cyan]Retrying another {review_cfg.max_cycles} review cycles...[/cyan]")

--- a/tests/test_review_loops.py
+++ b/tests/test_review_loops.py
@@ -167,7 +167,7 @@ class TestPrdReviewLoopMaxCycles:
             patch("ralph_pp.steps.prd.make_tool") as mock_make,
             patch(
                 "ralph_pp.steps.prd.prompt_max_cycles",
-                side_effect=lambda *a: next(prompt_responses),
+                side_effect=lambda *a, **kw: next(prompt_responses),
             ),
             patch("ralph_pp.steps.prd.get_head_sha", return_value="abc1234"),
             patch("ralph_pp.steps.prd.get_diff", return_value="(no diff)"),
@@ -383,6 +383,123 @@ class TestPromptMaxCycles:
                 "Post-run", 3, continue_label="Accept — finish without reviewer approval"
             )
         assert result == "continue"
+
+    def test_explore_option_disabled_by_default(self):
+        """Without allow_explore, choice 4 must not be a valid choice."""
+        with patch("ralph_pp.steps.prd.click.prompt") as mock_prompt:
+            mock_prompt.return_value = "3"
+            prompt_max_cycles("PRD", 3)
+        # Inspect the click.prompt call to confirm only 1/2/3 were offered
+        args, kwargs = mock_prompt.call_args
+        choice_obj = kwargs.get("type") or args[0]
+        # click.Choice exposes its choices via .choices
+        if hasattr(choice_obj, "choices"):
+            assert "4" not in choice_obj.choices
+
+    def test_explore_option_enabled(self):
+        """When allow_explore=True, choice 4 returns 'explore' (#120)."""
+        with patch("ralph_pp.steps.prd.click.prompt", return_value="4"):
+            assert prompt_max_cycles("PRD", 3, allow_explore=True) == "explore"
+
+    def test_explore_returns_other_actions_normally(self):
+        """allow_explore doesn't break the existing 1/2/3 mappings."""
+        with patch("ralph_pp.steps.prd.click.prompt", return_value="1"):
+            assert prompt_max_cycles("PRD", 3, allow_explore=True) == "quit"
+        with patch("ralph_pp.steps.prd.click.prompt", return_value="2"):
+            assert prompt_max_cycles("PRD", 3, allow_explore=True) == "retry"
+        with patch("ralph_pp.steps.prd.click.prompt", return_value="3"):
+            assert prompt_max_cycles("PRD", 3, allow_explore=True) == "continue"
+
+
+class TestExploreOption:
+    """Integration tests for #120 explore option in PRD review loop."""
+
+    def test_explore_launches_interactive_tool_then_re_reviews(self, tmp_path):
+        from ralph_pp.steps.prd import review_prd_loop
+
+        config = _make_config(prd_review=_review_cfg(max_cycles=1))
+        # Add an interactive tool
+        config.tools["claude-interactive"] = ToolConfig(
+            command="claude",
+            args=["{prompt}"],
+            interactive=True,
+        )
+        prd_file = tmp_path / "tasks" / "prd.md"
+        prd_file.parent.mkdir(parents=True)
+        prd_file.write_text("# PRD")
+
+        prompt_responses = iter(["explore", "continue"])
+        interactive_calls = []
+
+        def fake_make_tool(name, cfg):
+            mock_tool = MagicMock()
+            if name == "claude-interactive":
+
+                def fake_run(prompt, cwd):
+                    interactive_calls.append({"prompt": prompt, "cwd": cwd})
+                    return _ok_result("session done")
+
+                mock_tool.run.side_effect = fake_run
+            elif name == "codex":  # reviewer
+                # First call: rejection. Second call (after explore): LGTM.
+                mock_tool.run.side_effect = [
+                    _ok_result("1. severity: major\nproblem: thing"),
+                    _ok_result("LGTM"),
+                ]
+            else:  # claude (fixer)
+                mock_tool.run.return_value = _ok_result("fixed")
+            return mock_tool
+
+        with (
+            patch("ralph_pp.steps.prd.make_tool", side_effect=fake_make_tool),
+            patch(
+                "ralph_pp.steps.prd.prompt_max_cycles",
+                side_effect=lambda *a, **kw: next(prompt_responses),
+            ),
+            patch("ralph_pp.steps.prd.get_head_sha", return_value="abc1234"),
+            patch("ralph_pp.steps.prd.get_diff", return_value="(no diff)"),
+        ):
+            review_prd_loop(prd_file, tmp_path, config)
+
+        # Interactive tool was invoked exactly once
+        assert len(interactive_calls) == 1
+        # Prompt should mention the PRD file path
+        assert str(prd_file) in interactive_calls[0]["prompt"]
+
+    def test_explore_falls_back_to_retry_when_no_interactive_tool(self, tmp_path):
+        """If no interactive tool is configured, log error and continue retrying."""
+        from ralph_pp.steps.prd import review_prd_loop
+
+        config = _make_config(prd_review=_review_cfg(max_cycles=1))
+        # Note: no interactive tool added
+        prd_file = tmp_path / "tasks" / "prd.md"
+        prd_file.parent.mkdir(parents=True)
+        prd_file.write_text("# PRD")
+
+        prompt_responses = iter(["explore", "continue"])
+
+        with (
+            patch("ralph_pp.steps.prd.make_tool") as mock_make,
+            patch(
+                "ralph_pp.steps.prd.prompt_max_cycles",
+                side_effect=lambda *a, **kw: next(prompt_responses),
+            ),
+            patch("ralph_pp.steps.prd.get_head_sha", return_value="abc1234"),
+            patch("ralph_pp.steps.prd.get_diff", return_value="(no diff)"),
+        ):
+            reviewer_mock = MagicMock()
+            reviewer_mock.run.side_effect = [
+                _ok_result("1. severity: major\nproblem: alpha beta gamma"),
+                _ok_result("1. severity: major\nproblem: delta epsilon zeta"),
+            ]
+            fixer_mock = MagicMock()
+            fixer_mock.run.return_value = _ok_result("fixed")
+            mock_make.side_effect = lambda name, cfg: (
+                reviewer_mock if name == "codex" else fixer_mock
+            )
+
+            # Should not raise — falls back gracefully
+            review_prd_loop(prd_file, tmp_path, config)
 
 
 class TestPostReviewFixer:


### PR DESCRIPTION
When the PRD review loop reaches max cycles without LGTM and the remaining findings need **design judgment** (not just text fixes), the user previously had only quit/retry/continue. This adds a fourth option:

\`\`\`
Options:
  1) Quit — abort the workflow
  2) Retry — run another N review cycles
  3) Continue — proceed without reviewer approval
  4) Explore — open an interactive session to edit the PRD, then
               run another review cycle
\`\`\`

When the user picks **Explore**, ralph++ launches the configured interactive tool (\`claude-interactive\` by default; falls back to any tool with \`interactive: true\`) with a pre-loaded prompt that:

- points at the PRD file path
- includes the most recent reviewer findings as context
- tells the user to \`/exit\` when done

After the session ends, the loop runs another batch of review cycles to verify the user's edits.

The same option is wired into the **prd.json review loop** as well. Post-run review intentionally does NOT get the option — it operates on code, not text, and an interactive Claude session there would compete with the next iteration's coder pass.

## Implementation

- \`prompt_max_cycles()\` gained an \`allow_explore: bool = False\` parameter so existing callers (post-run review) keep the old 3-option flow without changes.
- New \`_launch_interactive_explore()\` helper finds the interactive tool, builds a context-loaded prompt, and runs it.
- Graceful fallback: if no interactive tool is configured, the option is still offered, but choosing it logs a clear error and falls back to retry instead of crashing.

## Test plan

- [x] \`make check\` — **273 passed** (was 268; 5 new tests)
- [x] \`prompt_max_cycles(allow_explore=False)\` does NOT include \`4\` in the click choices
- [x] \`prompt_max_cycles(allow_explore=True)\` returns \`\"explore\"\` for choice 4
- [x] Existing 1/2/3 mappings still work when \`allow_explore=True\`
- [x] **Integration**: \`review_prd_loop\` invoking \`Explore\` calls the interactive tool exactly once with the PRD file path in its prompt, then runs another review cycle to verify
- [x] **Graceful fallback**: when no interactive tool is configured, the loop logs an error and continues with the next retry instead of crashing

## Compatibility

- The new \`allow_explore\` parameter defaults to \`False\`, so any user code or test that calls \`prompt_max_cycles\` without it sees the old 3-option behavior.
- Updated one existing test (\`test_retry_runs_another_batch\`) whose lambda was swallowing only positional args — now uses \`**kw\` to accept the new keyword.

Closes #120