### PR TITLE
fix: show resume plan for --dry-run + --resume-worktree (#154)

### DIFF
--- a/ralph_pp/orchestrator.py
+++ b/ralph_pp/orchestrator.py
@@ -324,6 +324,8 @@ class Orchestrator:
         lines.append(f"Repo:          {cfg.repo_path}")
         lines.append(f"Mode:          {mode}")
         lines.append(f"Max iterations: {cfg.ralph.max_iterations}")
+        if self.resume_worktree is not None:
+            lines.append(f"Resuming:      {self.resume_worktree}")
 
         if prd_only:
             lines.append("\n[bold]Steps:[/bold]")
@@ -331,6 +333,22 @@ class Orchestrator:
             if not skip_prd_review:
                 lines.append("  2. Review PRD loop")
             lines.append("  → Stop (--prd-only)")
+        elif self.resume_worktree is not None:
+            lines.append("\n[bold]Steps:[/bold]")
+            lines.append("  1. Validate worktree + prd.json")
+            if mode == "orchestrated":
+                strategy = "backout" if orch.backout_on_failure else "fixup"
+                lines.append(f"  2. Orchestrated sandbox ({strategy})")
+                lines.append(
+                    f"     Coder: {orch.coder}  Reviewer: {orch.reviewer}  Fixer: {orch.fixer}"
+                )
+                if orch.test_commands:
+                    lines.append(f"     Tests: {', '.join(orch.test_commands)}")
+            else:
+                lines.append(f"  2. Delegated sandbox (tool: {cfg.ralph.sandbox_tool})")
+            if not skip_post_review:
+                lines.append(f"  3. Post-run review loop (max {cfg.post_review.max_cycles} cycles)")
+            lines.append("  4. Cleanup")
         else:
             lines.append("\n[bold]Steps:[/bold]")
             lines.append("  1. Create worktree + branch")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -196,3 +196,41 @@ class TestResumeWorktree:
         orch = Orchestrator("test-feature", cfg, resume_worktree=wt)
         with pytest.raises(ValueError, match="not a git directory"):
             orch.run()
+
+    def test_dry_run_resume_shows_resume_plan(self, tmp_path, capsys, monkeypatch):
+        """#154: --dry-run with --resume-worktree must print the resume plan,
+        not the fresh-run plan (no create-worktree / generate-PRD / convert-PRD).
+        """
+        from rich.console import Console
+
+        import ralph_pp.orchestrator as orch_mod
+        from ralph_pp.config import Config, OrchestratedConfig, PostReviewConfig, RalphConfig
+
+        # Widen the console so long tmp_path values don't wrap inside the panel.
+        monkeypatch.setattr(orch_mod, "console", Console(width=400))
+
+        cfg = Config.__new__(Config)
+        cfg.repo_path = tmp_path
+        cfg.ralph = RalphConfig(mode="delegated", max_iterations=7, sandbox_tool="claude")
+        cfg.post_review = PostReviewConfig(max_cycles=3)
+        cfg.hooks = {}
+        cfg.orchestrated = OrchestratedConfig()  # unused in delegated resume
+
+        wt = tmp_path / "existing-worktree"
+        # Dry-run should not touch the filesystem, so the path need not exist.
+
+        orch = Orchestrator("test-feature", cfg, dry_run=True, resume_worktree=wt)
+        orch.run()
+
+        out = capsys.readouterr().out
+        # Resume plan signals.
+        assert "Resuming:" in out
+        assert str(wt) in out
+        assert "Validate worktree" in out
+        assert "Delegated sandbox" in out
+        assert "Post-run review loop" in out
+        assert "Cleanup" in out
+        # Fresh-run steps must NOT appear
+        assert "Create worktree" not in out
+        assert "Generate PRD" not in out
+        assert "Convert PRD to prd.json" not in out


### PR DESCRIPTION
## Summary

- `Orchestrator._print_dry_run_plan` never consulted `self.resume_worktree`, so `--dry-run --resume-worktree <path>` printed the fresh-run plan (create worktree, generate PRD, convert PRD) — the exact steps resume skips.
- Add a resume branch to the plan printer: validate worktree + prd.json → sandbox → post-run review → cleanup, and surface the resume target path via a new `Resuming:` line.
- Add a regression test that monkeypatches the module-level Rich console to a wide width so long `tmp_path` values don't wrap inside the panel before assertions.

Closes #154.

## Test plan

- [x] `make check` clean (ruff, ruff format, pyright, pytest — 395 passed)
- [x] New test `TestResumeWorktree::test_dry_run_resume_shows_resume_plan` asserts the resume plan is printed and the fresh-run steps are absent
- [ ] Manual smoke: `uv run ralph++ run --dry-run --resume-worktree <existing-worktree> --feature foo --repo <repo> --config <cfg>` shows the resume plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)